### PR TITLE
FLPATH-3006: Add core infrastructure [2/5]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ coverage.*
 *.coverprofile
 profile.cov
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Dependency directories
+vendor/
 
 # Go workspace file
 go.work

--- a/cmd/service-provider-manager/main.go
+++ b/cmd/service-provider-manager/main.go
@@ -1,5 +1,98 @@
 package main
 
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	apiserver "github.com/dcm-project/service-provider-manager/internal/api_server"
+	"github.com/dcm-project/service-provider-manager/internal/config"
+)
+
 func main() {
+	cfg, err := config.Load()
+	if err != nil {
+		log.Fatalf("Failed to load config: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", cfg.Service.Address)
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	// TODO: Replace with real handler implementation
+	handler := &stubHandler{}
+
+	srv := apiserver.New(cfg, listener, handler)
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	log.Printf("Starting server on %s", listener.Addr().String())
+	if err := srv.Run(ctx); err != nil {
+		log.Fatalf("Server failed: %v", err)
+	}
 }
 
+// stubHandler implements server.StrictServerInterface with stub responses
+type stubHandler struct{}
+
+func (s *stubHandler) GetHealth(ctx context.Context, request server.GetHealthRequestObject) (server.GetHealthResponseObject, error) {
+	return server.GetHealth200JSONResponse{Status: ptr("ok")}, nil
+}
+
+func (s *stubHandler) ListProviders(ctx context.Context, request server.ListProvidersRequestObject) (server.ListProvidersResponseObject, error) {
+	return notImplemented(), nil
+}
+
+func (s *stubHandler) CreateProvider(ctx context.Context, request server.CreateProviderRequestObject) (server.CreateProviderResponseObject, error) {
+	return notImplemented(), nil
+}
+
+func (s *stubHandler) DeleteProvider(ctx context.Context, request server.DeleteProviderRequestObject) (server.DeleteProviderResponseObject, error) {
+	return notImplemented(), nil
+}
+
+func (s *stubHandler) GetProvider(ctx context.Context, request server.GetProviderRequestObject) (server.GetProviderResponseObject, error) {
+	return notImplemented(), nil
+}
+
+func (s *stubHandler) ApplyProvider(ctx context.Context, request server.ApplyProviderRequestObject) (server.ApplyProviderResponseObject, error) {
+	return notImplemented(), nil
+}
+
+func ptr(s string) *string { return &s }
+
+type notImplementedResponse struct{}
+
+func (notImplementedResponse) VisitListProvidersResponse(w http.ResponseWriter) error {
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}
+
+func (notImplementedResponse) VisitCreateProviderResponse(w http.ResponseWriter) error {
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}
+
+func (notImplementedResponse) VisitDeleteProviderResponse(w http.ResponseWriter) error {
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}
+
+func (notImplementedResponse) VisitGetProviderResponse(w http.ResponseWriter) error {
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}
+
+func (notImplementedResponse) VisitApplyProviderResponse(w http.ResponseWriter) error {
+	w.WriteHeader(http.StatusNotImplemented)
+	return nil
+}
+
+func notImplemented() notImplementedResponse { return notImplementedResponse{} }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.6
 require (
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-chi/chi/v5 v5.2.3
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/oapi-codegen/oapi-codegen/v2 v2.5.1
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/onsi/ginkgo/v2 v2.21.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/internal/api_server/server.go
+++ b/internal/api_server/server.go
@@ -1,0 +1,53 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/config"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+const gracefulShutdownTimeout = 5 * time.Second
+
+type Server struct {
+	cfg      *config.Config
+	listener net.Listener
+	handler  server.StrictServerInterface
+}
+
+func New(cfg *config.Config, listener net.Listener, handler server.StrictServerInterface) *Server {
+	return &Server{
+		cfg:      cfg,
+		listener: listener,
+		handler:  handler,
+	}
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	router := chi.NewRouter()
+	router.Use(middleware.Logger)
+	router.Use(middleware.Recoverer)
+
+	server.HandlerFromMux(server.NewStrictHandler(s.handler, nil), router)
+
+	srv := http.Server{Handler: router}
+
+	go func() {
+		<-ctx.Done()
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
+		defer cancel()
+		srv.SetKeepAlivesEnabled(false)
+		_ = srv.Shutdown(ctxTimeout)
+	}()
+
+	if err := srv.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"github.com/kelseyhightower/envconfig"
+)
+
+type Config struct {
+	Database *DBConfig
+	Service  *ServiceConfig
+}
+
+type DBConfig struct {
+	Type     string `envconfig:"DB_TYPE" default:"pgsql"`
+	Hostname string `envconfig:"DB_HOST" default:"localhost"`
+	Port     string `envconfig:"DB_PORT" default:"5432"`
+	Name     string `envconfig:"DB_NAME" default:"service-provider"`
+	User     string `envconfig:"DB_USER" default:"admin"`
+	Password string `envconfig:"DB_PASS" default:"adminpass"`
+}
+
+type ServiceConfig struct {
+	Address  string `envconfig:"SVC_ADDRESS" default:":8080"`
+	LogLevel string `envconfig:"SVC_LOG_LEVEL" default:"info"`
+}
+
+func Load() (*Config, error) {
+	cfg := &Config{}
+	if err := envconfig.Process("", cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}


### PR DESCRIPTION
# Add core infrastructure with configuration and HTTP server

Implements foundational infrastructure for DCM Service Provider Manager including environment-based configuration, HTTP server with graceful shutdown, and production-ready operational patterns.

# Add core infrastructure with configuration and HTTP server

Implements foundational infrastructure for DCM Service Provider Manager including environment-based configuration, HTTP server with graceful shutdown, and production-ready operational patterns.

## PR Series
1. Project scaffolding
2. **This PR** - Core infrastructure  
3. OpenAPI spec + code generation
4. Client library
5. Business logic + handlers

## Fixes
https://issues.redhat.com/browse/FLPATH-3006