### PR TITLE
FLPATH-3008: Add business logic and handlers [4/5]

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,39 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/workflows/check-*.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Start services
+        run: docker compose up -d --build --wait
+
+      - name: Run E2E tests
+        run: make test-e2e
+
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+
+WORKDIR /app
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the binary
+USER root
+RUN CGO_ENABLED=0 GOOS=linux go build -buildvcs=false -o service-provider-manager ./cmd/service-provider-manager
+
+# Runtime stage
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/service-provider-manager .
+
+EXPOSE 8080
+
+ENTRYPOINT ["./service-provider-manager"]

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ check-aep:
 	spectral lint --fail-severity=warn ./api/v1alpha1/openapi.yaml
 	spectral lint --fail-severity=warn ./api/v1alpha1/resource_manager/openapi.yaml
 
-COVER_PKGS := ./internal/store/...,./internal/config/...,./internal/api_server/...
+COVER_PKGS := ./internal/store/...,./internal/config/...,./internal/api_server/...,./internal/service/...,./internal/handlers/...
 
 test-coverage:
 	go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --cover --coverpkg=$(COVER_PKGS) --coverprofile=coverage.out

--- a/README.md
+++ b/README.md
@@ -2,6 +2,61 @@
 
 DCM Service Provider Manager - Registration and management of Service Providers.
 
+## Quick Start
+
+### Prerequisites
+
+- Go 1.25+
+- Podman or Docker with Compose
+
+### Run Locally
+
+```bash
+# Start the service with PostgreSQL
+podman-compose up -d
+
+# Check health
+curl http://localhost:8080/api/v1alpha1/health
+```
+
+### Build
+
+```bash
+make build        # Build binary
+make run          # Run locally (requires PostgreSQL)
+```
+
+### Test
+
+```bash
+make test         # Unit tests
+make test-e2e     # E2E tests (requires running services)
+```
+
+### API
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/api/v1alpha1/health` | Health check |
+| POST | `/api/v1alpha1/providers` | Register provider (idempotent) |
+| GET | `/api/v1alpha1/providers` | List providers |
+| GET | `/api/v1alpha1/providers/{id}` | Get provider |
+| PUT | `/api/v1alpha1/providers/{id}` | Update provider |
+| DELETE | `/api/v1alpha1/providers/{id}` | Delete provider |
+
+### Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SVC_ADDRESS` | `:8080` | Service listen address |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `service-provider` | Database name |
+| `DB_USER` | *(none)* | Database user (required for pgsql) |
+| `DB_PASS` | *(none)* | Database password (required for pgsql) |
+
 ## License
 
 Apache 2.0 - see [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Environment variables:
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
 | `DB_NAME` | `service-provider` | Database name |
-| `DB_USER` | `admin` | Database user |
-| `DB_PASS` | `adminpass` | Database password |
+| `DB_USER` | *(none)* | Database user (required for pgsql) |
+| `DB_PASS` | *(none)* | Database password (required for pgsql) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Environment variables:
 | `DB_HOST` | `localhost` | PostgreSQL host |
 | `DB_PORT` | `5432` | PostgreSQL port |
 | `DB_NAME` | `service-provider` | Database name |
-| `DB_USER` | *(none)* | Database user (required for pgsql) |
-| `DB_PASS` | *(none)* | Database password (required for pgsql) |
+| `DB_USER` | `admin` | Database user |
+| `DB_PASS` | `adminpass` | Database password |
 
 ## License
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,42 @@
+services:
+  postgres:
+    image: docker.io/library/postgres:16-alpine
+    environment:
+      POSTGRES_DB: service-provider
+      POSTGRES_USER: admin
+      POSTGRES_PASSWORD: adminpass
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U admin -d service-provider"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  service-provider-manager:
+    build:
+      context: .
+      dockerfile: Containerfile
+    environment:
+      DB_TYPE: pgsql
+      DB_HOST: postgres
+      DB_PORT: "5432"
+      DB_NAME: service-provider
+      DB_USER: admin
+      DB_PASS: adminpass
+      SVC_ADDRESS: ":8080"
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1alpha1/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dcm-project/service-provider-manager
 
-go 1.24.6
+go 1.25.5
 
 require (
 	github.com/getkin/kin-openapi v0.133.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,8 @@ type DBConfig struct {
 	Hostname string `envconfig:"DB_HOST" default:"localhost"`
 	Port     string `envconfig:"DB_PORT" default:"5432"`
 	Name     string `envconfig:"DB_NAME" default:"service-provider"`
-	User     string `envconfig:"DB_USER" default:"admin"`
-	Password string `envconfig:"DB_PASS" default:"adminpass"`
+	User     string `envconfig:"DB_USER"`
+	Password string `envconfig:"DB_PASS"`
 }
 
 type ServiceConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,8 @@ type DBConfig struct {
 	Hostname string `envconfig:"DB_HOST" default:"localhost"`
 	Port     string `envconfig:"DB_PORT" default:"5432"`
 	Name     string `envconfig:"DB_NAME" default:"service-provider"`
-	User     string `envconfig:"DB_USER"`
-	Password string `envconfig:"DB_PASS"`
+	User     string `envconfig:"DB_USER" default:"admin"`
+	Password string `envconfig:"DB_PASS" default:"adminpass"`
 }
 
 type ServiceConfig struct {

--- a/internal/handlers/handler.go
+++ b/internal/handlers/handler.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"context"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/service"
+)
+
+// Handler implements the generated StrictServerInterface for the Provider API.
+type Handler struct {
+	providerService *service.ProviderService
+}
+
+// NewHandler creates a new Handler with the given provider service.
+func NewHandler(providerService *service.ProviderService) *Handler {
+	return &Handler{providerService: providerService}
+}
+
+// Ensure Handler implements StrictServerInterface
+var _ server.StrictServerInterface = (*Handler)(nil)
+
+func (h *Handler) GetHealth(ctx context.Context, request server.GetHealthRequestObject) (server.GetHealthResponseObject, error) {
+	status := "ok"
+	path := "health"
+	return server.GetHealth200JSONResponse{Status: &status, Path: &path}, nil
+}
+
+func (h *Handler) ListProviders(ctx context.Context, request server.ListProvidersRequestObject) (server.ListProvidersResponseObject, error) {
+	var serviceType string
+	if request.Params.Type != nil {
+		serviceType = *request.Params.Type
+	}
+
+	providers, err := h.providerService.ListProviders(ctx, serviceType)
+	if err != nil {
+		return server.ListProviders400ApplicationProblemPlusJSONResponse(newError("list-error", "Failed to list providers", err.Error(), 400)), nil
+	}
+
+	return server.ListProviders200JSONResponse{Providers: &providers}, nil
+}
+
+func (h *Handler) CreateProvider(ctx context.Context, request server.CreateProviderRequestObject) (server.CreateProviderResponseObject, error) {
+	response, err := h.providerService.RegisterProvider(ctx, request.Body, request.Params.Id)
+	if err != nil {
+		if svcErr, ok := err.(*service.ServiceError); ok {
+			switch svcErr.Code {
+			case service.ErrCodeValidation:
+				return server.CreateProvider400ApplicationProblemPlusJSONResponse(newError("validation-error", "Validation failed", svcErr.Message, 400)), nil
+			case service.ErrCodeConflict:
+				return server.CreateProvider409ApplicationProblemPlusJSONResponse(newError("conflict", "Resource conflict", svcErr.Message, 409)), nil
+			}
+		}
+		return server.CreateProvider400ApplicationProblemPlusJSONResponse(newError("create-error", "Failed to create provider", err.Error(), 400)), nil
+	}
+
+	if response.Status != nil && *response.Status == server.Updated {
+		return server.CreateProvider200JSONResponse(*response), nil
+	}
+	return server.CreateProvider201JSONResponse(*response), nil
+}
+
+func (h *Handler) GetProvider(ctx context.Context, request server.GetProviderRequestObject) (server.GetProviderResponseObject, error) {
+	provider, err := h.providerService.GetProvider(ctx, request.ProviderId.String())
+	if err != nil {
+		if svcErr, ok := err.(*service.ServiceError); ok && svcErr.Code == service.ErrCodeNotFound {
+			return server.GetProvider404ApplicationProblemPlusJSONResponse(newError("not-found", "Provider not found", svcErr.Message, 404)), nil
+		}
+		return server.GetProvider400ApplicationProblemPlusJSONResponse(newError("get-error", "Failed to get provider", err.Error(), 400)), nil
+	}
+
+	return server.GetProvider200JSONResponse(*provider), nil
+}
+
+func (h *Handler) ApplyProvider(ctx context.Context, request server.ApplyProviderRequestObject) (server.ApplyProviderResponseObject, error) {
+	provider, err := h.providerService.UpdateProvider(ctx, request.ProviderId.String(), request.Body)
+	if err != nil {
+		if svcErr, ok := err.(*service.ServiceError); ok {
+			switch svcErr.Code {
+			case service.ErrCodeNotFound:
+				return server.ApplyProvider404ApplicationProblemPlusJSONResponse(newError("not-found", "Provider not found", svcErr.Message, 404)), nil
+			case service.ErrCodeConflict:
+				return server.ApplyProvider409ApplicationProblemPlusJSONResponse(newError("conflict", "Name conflict", svcErr.Message, 409)), nil
+			}
+		}
+		return server.ApplyProvider400ApplicationProblemPlusJSONResponse(newError("update-error", "Failed to update provider", err.Error(), 400)), nil
+	}
+
+	return server.ApplyProvider200JSONResponse(*provider), nil
+}
+
+func (h *Handler) DeleteProvider(ctx context.Context, request server.DeleteProviderRequestObject) (server.DeleteProviderResponseObject, error) {
+	err := h.providerService.DeleteProvider(ctx, request.ProviderId.String())
+	if err != nil {
+		if svcErr, ok := err.(*service.ServiceError); ok && svcErr.Code == service.ErrCodeNotFound {
+			return server.DeleteProvider404ApplicationProblemPlusJSONResponse(newError("not-found", "Provider not found", svcErr.Message, 404)), nil
+		}
+		return server.DeleteProvider400ApplicationProblemPlusJSONResponse(newError("delete-error", "Failed to delete provider", err.Error(), 400)), nil
+	}
+
+	return server.DeleteProvider204Response{}, nil
+}
+
+func newError(errType, title, detail string, status int) server.Error {
+	return server.Error{
+		Type:   errType,
+		Title:  title,
+		Detail: &detail,
+		Status: &status,
+	}
+}

--- a/internal/handlers/handler_test.go
+++ b/internal/handlers/handler_test.go
@@ -1,0 +1,296 @@
+package handlers_test
+
+import (
+	"context"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/handlers"
+	"github.com/dcm-project/service-provider-manager/internal/service"
+	"github.com/dcm-project/service-provider-manager/internal/store"
+	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var _ = Describe("Handler", func() {
+	var (
+		db      *gorm.DB
+		handler *handlers.Handler
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		db, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+			Logger: logger.Default.LogMode(logger.Silent),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(db.AutoMigrate(&model.Provider{})).To(Succeed())
+
+		dataStore := store.NewStore(db)
+		providerService := service.NewProviderService(dataStore)
+		handler = handlers.NewHandler(providerService)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	})
+
+	Describe("GetHealth", func() {
+		It("returns ok", func() {
+			resp, err := handler.GetHealth(ctx, server.GetHealthRequestObject{})
+
+			Expect(err).NotTo(HaveOccurred())
+			jsonResp, ok := resp.(server.GetHealth200JSONResponse)
+			Expect(ok).To(BeTrue())
+			Expect(*jsonResp.Status).To(Equal("ok"))
+		})
+	})
+
+	Describe("CreateProvider", func() {
+		It("creates and returns 201", func() {
+			req := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "test-provider",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+
+			resp, err := handler.CreateProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.CreateProvider201JSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("returns 200 for idempotent re-registration", func() {
+			req := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "idempotent-provider",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+
+			// First call creates
+			resp1, err := handler.CreateProvider(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp1.(server.CreateProvider201JSONResponse)
+			Expect(ok).To(BeTrue())
+
+			// Second call updates (same name, no ID)
+			resp2, err := handler.CreateProvider(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			_, ok = resp2.(server.CreateProvider200JSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("returns 409 for name conflict with different ID", func() {
+			// Create first provider
+			req1 := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "conflict-name",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+			_, err := handler.CreateProvider(ctx, req1)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Try to create with same name but different ID
+			differentID := openapi_types.UUID(uuid.New())
+			req2 := server.CreateProviderRequestObject{
+				Params: server.CreateProviderParams{Id: &differentID},
+				Body: &server.Provider{
+					Name:          "conflict-name",
+					Endpoint:      "https://other.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+
+			resp, err := handler.CreateProvider(ctx, req2)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.CreateProvider409ApplicationProblemPlusJSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("ListProviders", func() {
+		It("returns empty list initially", func() {
+			req := server.ListProvidersRequestObject{}
+
+			resp, err := handler.ListProviders(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			jsonResp, ok := resp.(server.ListProviders200JSONResponse)
+			Expect(ok).To(BeTrue())
+			Expect(*jsonResp.Providers).To(BeEmpty())
+		})
+
+		It("returns providers", func() {
+			// Create providers first
+			for _, name := range []string{"provider-1", "provider-2"} {
+				createReq := server.CreateProviderRequestObject{
+					Body: &server.Provider{
+						Name:          name,
+						Endpoint:      "https://example.com",
+						ServiceType:   "vm",
+						SchemaVersion: "v1alpha1",
+					},
+				}
+				_, err := handler.CreateProvider(ctx, createReq)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			resp, err := handler.ListProviders(ctx, server.ListProvidersRequestObject{})
+
+			Expect(err).NotTo(HaveOccurred())
+			jsonResp, ok := resp.(server.ListProviders200JSONResponse)
+			Expect(ok).To(BeTrue())
+			Expect(*jsonResp.Providers).To(HaveLen(2))
+		})
+	})
+
+	Describe("GetProvider", func() {
+		It("returns provider", func() {
+			// Create a provider first
+			createReq := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "get-me",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+			createResp, _ := handler.CreateProvider(ctx, createReq)
+			created := createResp.(server.CreateProvider201JSONResponse)
+
+			req := server.GetProviderRequestObject{
+				ProviderId: *created.Id,
+			}
+
+			resp, err := handler.GetProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			jsonResp, ok := resp.(server.GetProvider200JSONResponse)
+			Expect(ok).To(BeTrue())
+			Expect(jsonResp.Name).To(Equal("get-me"))
+		})
+
+		It("returns 404 for non-existent provider", func() {
+			req := server.GetProviderRequestObject{
+				ProviderId: openapi_types.UUID(uuid.New()),
+			}
+
+			resp, err := handler.GetProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.GetProvider404ApplicationProblemPlusJSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("ApplyProvider", func() {
+		It("updates existing provider", func() {
+			// Create a provider first
+			createReq := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "to-update",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+			createResp, _ := handler.CreateProvider(ctx, createReq)
+			created := createResp.(server.CreateProvider201JSONResponse)
+
+			// Update it
+			updateReq := server.ApplyProviderRequestObject{
+				ProviderId: *created.Id,
+				Body: &server.Provider{
+					Id:            created.Id,
+					Name:          "to-update",
+					Endpoint:      "https://updated.example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+
+			resp, err := handler.ApplyProvider(ctx, updateReq)
+
+			Expect(err).NotTo(HaveOccurred())
+			jsonResp, ok := resp.(server.ApplyProvider200JSONResponse)
+			Expect(ok).To(BeTrue())
+			Expect(jsonResp.Endpoint).To(Equal("https://updated.example.com"))
+		})
+
+		It("returns 404 for non-existent provider", func() {
+			req := server.ApplyProviderRequestObject{
+				ProviderId: openapi_types.UUID(uuid.New()),
+				Body: &server.Provider{
+					Name:          "test",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+
+			resp, err := handler.ApplyProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.ApplyProvider404ApplicationProblemPlusJSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+	})
+
+	Describe("DeleteProvider", func() {
+		It("deletes provider and returns 204", func() {
+			// Create a provider first
+			createReq := server.CreateProviderRequestObject{
+				Body: &server.Provider{
+					Name:          "to-delete",
+					Endpoint:      "https://example.com",
+					ServiceType:   "vm",
+					SchemaVersion: "v1alpha1",
+				},
+			}
+			createResp, _ := handler.CreateProvider(ctx, createReq)
+			created := createResp.(server.CreateProvider201JSONResponse)
+
+			req := server.DeleteProviderRequestObject{
+				ProviderId: *created.Id,
+			}
+
+			resp, err := handler.DeleteProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.DeleteProvider204Response)
+			Expect(ok).To(BeTrue())
+		})
+
+		It("returns 404 for non-existent provider", func() {
+			req := server.DeleteProviderRequestObject{
+				ProviderId: openapi_types.UUID(uuid.New()),
+			}
+
+			resp, err := handler.DeleteProvider(ctx, req)
+
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := resp.(server.DeleteProvider404ApplicationProblemPlusJSONResponse)
+			Expect(ok).To(BeTrue())
+		})
+	})
+})

--- a/internal/handlers/handlers_suite_test.go
+++ b/internal/handlers/handlers_suite_test.go
@@ -1,0 +1,14 @@
+package handlers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handlers Suite")
+}
+

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -1,0 +1,54 @@
+package service
+
+import (
+	"time"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ModelToProvider converts a database model to an API response type
+func ModelToProvider(m *model.Provider) *server.Provider {
+	id := openapi_types.UUID(m.ID)
+	return &server.Provider{
+		Id:            &id,
+		Name:          m.Name,
+		ServiceType:   m.ServiceType,
+		SchemaVersion: m.SchemaVersion,
+		Endpoint:      m.Endpoint,
+		CreateTime:    ptrTime(m.CreateTime),
+		UpdateTime:    ptrTime(m.UpdateTime),
+	}
+}
+
+// ModelToProviderWithStatus converts a database model to an API response with status
+func ModelToProviderWithStatus(m *model.Provider, status server.ProviderStatus) *server.Provider {
+	p := ModelToProvider(m)
+	p.Status = &status
+	return p
+}
+
+// ProviderToModel converts an API request to a database model
+func ProviderToModel(req *server.Provider, id uuid.UUID) model.Provider {
+	now := time.Now()
+	return model.Provider{
+		ID:            id,
+		Name:          req.Name,
+		ServiceType:   req.ServiceType,
+		SchemaVersion: req.SchemaVersion,
+		Endpoint:      req.Endpoint,
+		CreateTime:    now,
+		UpdateTime:    now,
+	}
+}
+
+// Helper functions for pointer conversions
+
+func ptrTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -1,0 +1,18 @@
+package service
+
+// Error codes returned by service operations.
+const (
+	ErrCodeNotFound   = "NOT_FOUND"
+	ErrCodeConflict   = "CONFLICT"
+	ErrCodeValidation = "VALIDATION"
+)
+
+// ServiceError represents a business logic error with a code for HTTP mapping.
+type ServiceError struct {
+	Code    string
+	Message string
+}
+
+func (e *ServiceError) Error() string {
+	return e.Message
+}

--- a/internal/service/provider.go
+++ b/internal/service/provider.go
@@ -1,0 +1,221 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/store"
+	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// ProviderService handles business logic for provider management.
+type ProviderService struct {
+	store store.Store
+}
+
+// NewProviderService creates a new ProviderService with the given store.
+func NewProviderService(store store.Store) *ProviderService {
+	return &ProviderService{store: store}
+}
+
+// RegisterOrUpdateProvider implements idempotent provider registration per the DCM spec.
+// Returns status "registered" for new providers, "updated" for existing ones.
+// Returns ErrCodeConflict if name exists with different ID or ID exists with different name.
+func (s *ProviderService) RegisterOrUpdateProvider(ctx context.Context, req *server.Provider, queryID *openapi_types.UUID) (*server.Provider, error) {
+	requestedID := s.parseProviderID(req.Id, queryID)
+
+	existing, err := s.findExistingByName(ctx, req.Name, requestedID)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing != nil {
+		updated, err := s.updateExistingProvider(ctx, existing, req)
+		if err != nil {
+			return nil, err
+		}
+		return ModelToProviderWithStatus(updated, server.Updated), nil
+	}
+
+	providerID, err := s.resolveProviderID(ctx, requestedID)
+	if err != nil {
+		return nil, err
+	}
+
+	providerModel := ProviderToModel(req, providerID)
+	created, err := s.store.Provider().Create(ctx, providerModel)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Created provider: %s (%s)", created.Name, created.ID)
+	return ModelToProviderWithStatus(created, server.Registered), nil
+}
+
+// parseProviderID extracts the provider ID from request body or query parameter.
+func (s *ProviderService) parseProviderID(bodyID *openapi_types.UUID, queryID *openapi_types.UUID) *uuid.UUID {
+	if bodyID != nil {
+		id := uuid.UUID(*bodyID)
+		return &id
+	}
+	if queryID != nil {
+		id := uuid.UUID(*queryID)
+		return &id
+	}
+	return nil
+}
+
+// findExistingByName returns the existing provider if name exists and is valid for update.
+// Returns ErrCodeConflict if name exists with a different ID than requested.
+func (s *ProviderService) findExistingByName(ctx context.Context, name string, requestedID *uuid.UUID) (*model.Provider, error) {
+	existing, err := s.store.Provider().GetByName(ctx, name)
+	if err != nil {
+		if errors.Is(err, store.ErrProviderNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if requestedID != nil && existing.ID != *requestedID {
+		return nil, &ServiceError{
+			Code:    ErrCodeConflict,
+			Message: fmt.Sprintf("name '%s' already exists with a different provider ID", name),
+		}
+	}
+
+	return existing, nil
+}
+
+// resolveProviderID returns the requested ID after checking for conflicts, or generates a new one.
+func (s *ProviderService) resolveProviderID(ctx context.Context, requestedID *uuid.UUID) (uuid.UUID, error) {
+	if requestedID == nil {
+		return uuid.New(), nil
+	}
+
+	exists, err := s.store.Provider().ExistsByID(ctx, *requestedID)
+	if err != nil {
+		return uuid.UUID{}, err
+	}
+	if exists {
+		return uuid.UUID{}, &ServiceError{
+			Code:    ErrCodeConflict,
+			Message: fmt.Sprintf("provider with ID '%s' already exists", *requestedID),
+		}
+	}
+
+	return *requestedID, nil
+}
+
+func (s *ProviderService) updateExistingProvider(ctx context.Context, existing *model.Provider, req *server.Provider) (*model.Provider, error) {
+	existing.Name = req.Name
+	existing.ServiceType = req.ServiceType
+	existing.SchemaVersion = req.SchemaVersion
+	existing.Endpoint = req.Endpoint
+	existing.UpdateTime = time.Now()
+
+	updated, err := s.store.Provider().Update(ctx, *existing)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Updated provider: %s (%s)", updated.Name, updated.ID)
+	return updated, nil
+}
+
+// GetProvider retrieves a provider by ID. Returns ErrCodeNotFound if not found.
+func (s *ProviderService) GetProvider(ctx context.Context, providerID string) (*server.Provider, error) {
+	id, err := uuid.Parse(providerID)
+	if err != nil {
+		return nil, &ServiceError{Code: ErrCodeValidation, Message: "invalid provider ID format"}
+	}
+
+	provider, err := s.store.Provider().Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrProviderNotFound) {
+			return nil, &ServiceError{Code: ErrCodeNotFound, Message: fmt.Sprintf("provider %s not found", providerID)}
+		}
+		return nil, err
+	}
+
+	return ModelToProvider(provider), nil
+}
+
+// ListProviders returns all providers, optionally filtered by service type.
+func (s *ProviderService) ListProviders(ctx context.Context, serviceType string) ([]server.Provider, error) {
+	var filter *store.ProviderFilter
+	if serviceType != "" {
+		filter = &store.ProviderFilter{ServiceType: &serviceType}
+	}
+
+	providers, err := s.store.Provider().List(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]server.Provider, len(providers))
+	for i, p := range providers {
+		result[i] = *ModelToProvider(&p)
+	}
+
+	return result, nil
+}
+
+// UpdateProvider updates an existing provider. Returns ErrCodeNotFound if provider
+// doesn't exist, or ErrCodeConflict if the new name is already taken.
+func (s *ProviderService) UpdateProvider(ctx context.Context, providerID string, update *server.Provider) (*server.Provider, error) {
+	id, err := uuid.Parse(providerID)
+	if err != nil {
+		return nil, &ServiceError{Code: ErrCodeValidation, Message: "invalid provider ID format"}
+	}
+
+	existing, err := s.store.Provider().Get(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrProviderNotFound) {
+			return nil, &ServiceError{Code: ErrCodeNotFound, Message: fmt.Sprintf("provider %s not found", providerID)}
+		}
+		return nil, err
+	}
+
+	// Check for name conflict
+	if update.Name != existing.Name {
+		other, err := s.store.Provider().GetByName(ctx, update.Name)
+		if err != nil && !errors.Is(err, store.ErrProviderNotFound) {
+			return nil, err
+		}
+		if other != nil && other.ID != id {
+			return nil, &ServiceError{Code: ErrCodeConflict, Message: fmt.Sprintf("name '%s' is already taken", update.Name)}
+		}
+	}
+
+	updated, err := s.updateExistingProvider(ctx, existing, update)
+	if err != nil {
+		return nil, err
+	}
+
+	return ModelToProvider(updated), nil
+}
+
+// DeleteProvider removes a provider by ID. Returns ErrCodeNotFound if not found.
+func (s *ProviderService) DeleteProvider(ctx context.Context, providerID string) error {
+	id, err := uuid.Parse(providerID)
+	if err != nil {
+		return &ServiceError{Code: ErrCodeValidation, Message: "invalid provider ID format"}
+	}
+
+	err = s.store.Provider().Delete(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrProviderNotFound) {
+			return &ServiceError{Code: ErrCodeNotFound, Message: fmt.Sprintf("provider %s not found", providerID)}
+		}
+		return err
+	}
+
+	log.Printf("Deleted provider: %s", providerID)
+	return nil
+}

--- a/internal/service/provider_test.go
+++ b/internal/service/provider_test.go
@@ -1,0 +1,250 @@
+package service_test
+
+import (
+	"context"
+
+	"github.com/dcm-project/service-provider-manager/internal/api/server"
+	"github.com/dcm-project/service-provider-manager/internal/service"
+	"github.com/dcm-project/service-provider-manager/internal/store"
+	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var _ = Describe("ProviderService", func() {
+	var (
+		db              *gorm.DB
+		dataStore       store.Store
+		providerService *service.ProviderService
+		ctx             context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		db, err = gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+			Logger: logger.Default.LogMode(logger.Silent),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(db.AutoMigrate(&model.Provider{})).To(Succeed())
+
+		dataStore = store.NewStore(db)
+		providerService = service.NewProviderService(dataStore)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		dataStore.Close()
+	})
+
+	Describe("RegisterProvider", func() {
+		It("creates a new provider", func() {
+			req := newProvider("new-provider")
+
+			resp, err := providerService.RegisterProvider(ctx, req, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Status).NotTo(BeNil())
+			Expect(*resp.Status).To(Equal(server.Registered))
+			Expect(resp.Name).To(Equal("new-provider"))
+		})
+
+		It("updates existing provider with same name and ID", func() {
+			req := newProvider("update-test")
+			resp1, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			// Re-register with same ID
+			req.Id = resp1.Id
+			req.Endpoint = "https://updated.example.com"
+			resp2, err := providerService.RegisterProvider(ctx, req, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp2.Status).NotTo(BeNil())
+			Expect(*resp2.Status).To(Equal(server.Updated))
+		})
+
+		It("updates existing provider with same name and no ID (idempotent)", func() {
+			req := newProvider("idempotent-test")
+			resp1, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			// Re-register with same name but NO ID
+			req2 := newProvider("idempotent-test")
+			req2.Endpoint = "https://updated.example.com"
+			resp2, err := providerService.RegisterProvider(ctx, req2, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp2.Status).NotTo(BeNil())
+			Expect(*resp2.Status).To(Equal(server.Updated))
+			Expect(resp2.Id.String()).To(Equal(resp1.Id.String())) // Same ID returned
+			Expect(resp2.Endpoint).To(Equal("https://updated.example.com"))
+		})
+
+		It("returns conflict when name exists with different ID", func() {
+			req := newProvider("conflict-name")
+			providerService.RegisterProvider(ctx, req, nil)
+
+			// Try with different ID
+			newID := openapi_types.UUID(uuid.New())
+			req.Id = &newID
+			_, err := providerService.RegisterProvider(ctx, req, nil)
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeConflict))
+		})
+
+		It("returns conflict when providerID exists with different name", func() {
+			req := newProvider("first-name")
+			resp, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			// Try with same ID but different name
+			req2 := newProvider("second-name")
+			req2.Id = resp.Id
+			_, err := providerService.RegisterProvider(ctx, req2, nil)
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeConflict))
+		})
+	})
+
+	Describe("GetProvider", func() {
+		It("returns the provider", func() {
+			req := newProvider("get-test")
+			resp, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			provider, err := providerService.GetProvider(ctx, resp.Id.String())
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(provider.Name).To(Equal("get-test"))
+		})
+
+		It("returns error for non-existent provider", func() {
+			_, err := providerService.GetProvider(ctx, uuid.New().String())
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeNotFound))
+		})
+	})
+
+	Describe("ListProviders", func() {
+		It("returns all providers", func() {
+			providerService.RegisterProvider(ctx, newProvider("p1"), nil)
+			providerService.RegisterProvider(ctx, newProvider("p2"), nil)
+
+			providers, err := providerService.ListProviders(ctx, "")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(providers).To(HaveLen(2))
+		})
+
+		It("filters by service type", func() {
+			req1 := newProvider("vm-provider")
+			req1.ServiceType = "vm"
+			providerService.RegisterProvider(ctx, req1, nil)
+
+			req2 := newProvider("container-provider")
+			req2.ServiceType = "container"
+			providerService.RegisterProvider(ctx, req2, nil)
+
+			providers, err := providerService.ListProviders(ctx, "vm")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(providers).To(HaveLen(1))
+		})
+	})
+
+	Describe("UpdateProvider", func() {
+		It("updates the provider", func() {
+			req := newProvider("update-provider")
+			resp, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			update := &server.Provider{
+				Id:            resp.Id,
+				Name:          "update-provider",
+				Endpoint:      "https://updated.example.com",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			}
+
+			updated, err := providerService.UpdateProvider(ctx, resp.Id.String(), update)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Endpoint).To(Equal("https://updated.example.com"))
+		})
+
+		It("returns conflict when renaming to existing name", func() {
+			// Create two providers
+			providerService.RegisterProvider(ctx, newProvider("original-name"), nil)
+			resp2, _ := providerService.RegisterProvider(ctx, newProvider("to-rename"), nil)
+
+			// Try to rename second provider to first provider's name
+			update := &server.Provider{
+				Name:          "original-name",
+				Endpoint:      "https://example.com",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			}
+
+			_, err := providerService.UpdateProvider(ctx, resp2.Id.String(), update)
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeConflict))
+		})
+
+		It("returns error for non-existent provider", func() {
+			update := &server.Provider{
+				Name:          "test",
+				Endpoint:      "https://example.com",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			}
+
+			_, err := providerService.UpdateProvider(ctx, uuid.New().String(), update)
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeNotFound))
+		})
+	})
+
+	Describe("DeleteProvider", func() {
+		It("deletes the provider", func() {
+			req := newProvider("to-delete")
+			resp, _ := providerService.RegisterProvider(ctx, req, nil)
+
+			err := providerService.DeleteProvider(ctx, resp.Id.String())
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("returns error for non-existent provider", func() {
+			err := providerService.DeleteProvider(ctx, uuid.New().String())
+
+			Expect(err).To(HaveOccurred())
+			svcErr, ok := err.(*service.ServiceError)
+			Expect(ok).To(BeTrue())
+			Expect(svcErr.Code).To(Equal(service.ErrCodeNotFound))
+		})
+	})
+})
+
+func newProvider(name string) *server.Provider {
+	return &server.Provider{
+		Name:          name,
+		Endpoint:      "https://example.com/api",
+		ServiceType:   "vm",
+		SchemaVersion: "v1alpha1",
+	}
+}

--- a/internal/service/service_suite_test.go
+++ b/internal/service/service_suite_test.go
@@ -1,0 +1,14 @@
+package service_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service Suite")
+}
+

--- a/internal/store/provider.go
+++ b/internal/store/provider.go
@@ -29,6 +29,7 @@ type Provider interface {
 	Update(ctx context.Context, provider model.Provider) (*model.Provider, error)
 	Get(ctx context.Context, id uuid.UUID) (*model.Provider, error)
 	GetByName(ctx context.Context, name string) (*model.Provider, error)
+	ExistsByID(ctx context.Context, id uuid.UUID) (bool, error)
 }
 
 type ProviderStore struct {
@@ -109,4 +110,16 @@ func (s *ProviderStore) GetByName(ctx context.Context, name string) (*model.Prov
 		return nil, err
 	}
 	return &provider, nil
+}
+
+func (s *ProviderStore) ExistsByID(ctx context.Context, id uuid.UUID) (bool, error) {
+	var provider model.Provider
+	err := s.db.WithContext(ctx).Select("id").Where(&model.Provider{ID: id}).Take(&provider).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/store/provider.go
+++ b/internal/store/provider.go
@@ -22,8 +22,15 @@ type ProviderFilter struct {
 	ServiceType *string
 }
 
+// Pagination contains options for paginated queries.
+type Pagination struct {
+	Limit  int
+	Offset int
+}
+
 type Provider interface {
-	List(ctx context.Context, filter *ProviderFilter) (model.ProviderList, error)
+	List(ctx context.Context, filter *ProviderFilter, pagination *Pagination) (model.ProviderList, error)
+	Count(ctx context.Context, filter *ProviderFilter) (int64, error)
 	Create(ctx context.Context, provider model.Provider) (*model.Provider, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	Update(ctx context.Context, provider model.Provider) (*model.Provider, error)
@@ -42,7 +49,7 @@ func NewProvider(db *gorm.DB) Provider {
 	return &ProviderStore{db: db}
 }
 
-func (s *ProviderStore) List(ctx context.Context, filter *ProviderFilter) (model.ProviderList, error) {
+func (s *ProviderStore) List(ctx context.Context, filter *ProviderFilter, pagination *Pagination) (model.ProviderList, error) {
 	var providers model.ProviderList
 	query := s.db.WithContext(ctx)
 
@@ -55,10 +62,36 @@ func (s *ProviderStore) List(ctx context.Context, filter *ProviderFilter) (model
 		}
 	}
 
+	// Apply consistent ordering for pagination
+	query = query.Order("create_time ASC, id ASC")
+
+	if pagination != nil {
+		query = query.Limit(pagination.Limit).Offset(pagination.Offset)
+	}
+
 	if err := query.Find(&providers).Error; err != nil {
 		return nil, err
 	}
 	return providers, nil
+}
+
+func (s *ProviderStore) Count(ctx context.Context, filter *ProviderFilter) (int64, error) {
+	var count int64
+	query := s.db.WithContext(ctx).Model(&model.Provider{})
+
+	if filter != nil {
+		if filter.Name != nil {
+			query = query.Where(&model.Provider{Name: *filter.Name})
+		}
+		if filter.ServiceType != nil {
+			query = query.Where(&model.Provider{ServiceType: *filter.ServiceType})
+		}
+	}
+
+	if err := query.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func (s *ProviderStore) Create(ctx context.Context, provider model.Provider) (*model.Provider, error) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,0 +1,15 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}

--- a/test/e2e/provider_test.go
+++ b/test/e2e/provider_test.go
@@ -1,0 +1,147 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/dcm-project/service-provider-manager/api/v1alpha1"
+	"github.com/dcm-project/service-provider-manager/pkg/client"
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Provider API", func() {
+	var (
+		apiClient *client.ClientWithResponses
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		baseURL := os.Getenv("API_URL")
+		if baseURL == "" {
+			baseURL = "http://localhost:8080/api/v1alpha1"
+		}
+
+		var err error
+		apiClient, err = client.NewClientWithResponses(baseURL)
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx = context.Background()
+	})
+
+	Describe("Health", func() {
+		It("returns healthy status", func() {
+			resp, err := apiClient.GetHealthWithResponse(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(resp.JSON200).NotTo(BeNil())
+			Expect(*resp.JSON200.Status).To(Equal("ok"))
+		})
+	})
+
+	Describe("Provider CRUD", func() {
+		It("creates, reads, updates, and deletes a provider", func() {
+			By("creating a new provider")
+			createResp, err := apiClient.CreateProviderWithResponse(ctx, nil, v1alpha1.Provider{
+				Name:          "e2e-test-provider",
+				Endpoint:      "https://example.com/api",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(createResp.StatusCode()).To(Equal(http.StatusCreated))
+			Expect(createResp.JSON201).NotTo(BeNil())
+			Expect(createResp.JSON201.Id).NotTo(BeNil())
+			Expect(*createResp.JSON201.Status).To(Equal(v1alpha1.Registered))
+
+			providerID := *createResp.JSON201.Id
+
+			By("getting the provider")
+			getResp, err := apiClient.GetProviderWithResponse(ctx, providerID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(getResp.JSON200.Name).To(Equal("e2e-test-provider"))
+
+			By("re-registering without ID (idempotent update)")
+			reregResp, err := apiClient.CreateProviderWithResponse(ctx, nil, v1alpha1.Provider{
+				Name:          "e2e-test-provider",
+				Endpoint:      "https://updated.example.com/api",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reregResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(reregResp.JSON200).NotTo(BeNil())
+			Expect(*reregResp.JSON200.Status).To(Equal(v1alpha1.Updated))
+			Expect(reregResp.JSON200.Id.String()).To(Equal(providerID.String()))
+
+			By("listing providers")
+			listResp, err := apiClient.ListProvidersWithResponse(ctx, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(listResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(listResp.JSON200.Providers).NotTo(BeNil())
+			Expect(len(*listResp.JSON200.Providers)).To(BeNumerically(">=", 1))
+
+			By("updating the provider")
+			updateResp, err := apiClient.ApplyProviderWithResponse(ctx, providerID, v1alpha1.Provider{
+				Name:          "e2e-test-provider-updated",
+				Endpoint:      "https://updated.example.com/api",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updateResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(updateResp.JSON200.Name).To(Equal("e2e-test-provider-updated"))
+
+			By("deleting the provider")
+			deleteResp, err := apiClient.DeleteProviderWithResponse(ctx, providerID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteResp.StatusCode()).To(Equal(http.StatusNoContent))
+
+			By("verifying provider is deleted")
+			getDeletedResp, err := apiClient.GetProviderWithResponse(ctx, providerID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getDeletedResp.StatusCode()).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("Conflict scenarios", func() {
+		var providerID openapi_types.UUID
+
+		BeforeEach(func() {
+			resp, err := apiClient.CreateProviderWithResponse(ctx, nil, v1alpha1.Provider{
+				Name:          "conflict-test-provider",
+				Endpoint:      "https://example.com/api",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode()).To(Equal(http.StatusCreated))
+			providerID = *resp.JSON201.Id
+		})
+
+		AfterEach(func() {
+			apiClient.DeleteProviderWithResponse(ctx, providerID)
+		})
+
+		It("returns 409 when registering same name with different ID", func() {
+			newID := openapi_types.UUID(uuid.New())
+			params := &v1alpha1.CreateProviderParams{Id: &newID}
+
+			resp, err := apiClient.CreateProviderWithResponse(ctx, params, v1alpha1.Provider{
+				Name:          "conflict-test-provider",
+				Endpoint:      "https://other.example.com/api",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.StatusCode()).To(Equal(http.StatusConflict))
+		})
+	})
+})


### PR DESCRIPTION
Adds the service layer and HTTP handlers for provider registration.

The ProviderService implements idempotent registration as described in the [sp-registration-flow](https://github.com/dcm-project/enhancements/blob/main/enhancements/sp-registration-flow/sp-registration-flow.md) enhancement. Handlers wire everything together and return proper error responses.

![2026-01-26-provider-crud](https://github.com/user-attachments/assets/dfdb64d1-e69e-41b9-acca-44c7111bef4d)

## PR Series

1. OpenAPI spec + code generation
2. Core infrastructure
3. Data layer
4. **This PR** - Business logic + handlers
5. Client library

## Fixes
https://issues.redhat.com/browse/FLPATH-3008
