### PR TITLE
Improve repository governance and automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gciavarrini @gabriel-farache @jenniferubah @machacekondra @ygalblum

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "deps"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "build"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thank you for your interest in contributing to the DCM Service Provider Manager.
+
+## Getting Started
+
+1. Read the [DCM Enhancements](https://dcm-project.github.io/docs/enhancements/) for context
+2. Fork the repository
+3. Clone your fork and create a branch for your changes
+4. Make your changes and ensure tests pass
+5. Submit a pull request
+
+## Development
+
+```bash
+make build      # Build the binary
+make test       # Run unit tests
+make test-e2e   # Run E2E tests (requires podman-compose up)
+make fmt        # Format code
+make vet        # Run linter
+```
+
+## API Changes
+
+This project uses OpenAPI-first development. To modify the API:
+
+1. Edit `api/v1alpha1/openapi.yaml`
+2. Run `make generate-api` to regenerate code
+3. Run `make check-aep` to validate AEP compliance
+
+Never edit generated files (`*.gen.go`) directly.
+
+## Pull Requests
+
+- All commits must be signed off (DCO): `git commit -s`
+- PRs require approval from a code owner
+- CI must pass before merging
+
+## Code of Conduct
+
+Be respectful and constructive in all interactions.

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM registry.access.redhat.com/ubi9/go-toolset:latest AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25.5 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Adds Dependabot, CODEOWNERS, and contributing guide.
Pins go-toolset image so Dependabot can track updates.

Once merged, enable "Require review from Code Owners" in branch protection.