### PR TITLE
Fix path-filtered workflows for required checks

### DIFF
--- a/.github/workflows/check-aep.yaml
+++ b/.github/workflows/check-aep.yaml
@@ -2,9 +2,7 @@ name: Check AEP Compliance
 
 on:
   pull_request:
-    paths:
-      - 'api/**/openapi.yaml'
-      - '.spectral.yaml'
+    branches: [main]
 
 jobs:
   check-aep:
@@ -12,9 +10,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for relevant changes
+        uses: tj-actions/changed-files@v47
+        id: filter
+        with:
+          files: |
+            api/**/openapi.yaml
+            .spectral.yaml
+
       - name: Install Spectral
+        if: steps.filter.outputs.any_changed == 'true'
         run: npm install -g @stoplight/spectral-cli
 
       - name: Check AEP compliance
+        if: steps.filter.outputs.any_changed == 'true'
         run: make check-aep
 
+      - name: Skip
+        if: steps.filter.outputs.any_changed == 'false'
+        run: echo "No API changes, skipping check"

--- a/.github/workflows/check-generate.yaml
+++ b/.github/workflows/check-generate.yaml
@@ -3,9 +3,6 @@ name: Check Generated Files
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'api/**'
-      - '**/*.gen.cfg'
 
 jobs:
   check:
@@ -13,11 +10,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for relevant changes
+        uses: tj-actions/changed-files@v47
+        id: filter
+        with:
+          files: |
+            api/**
+            **/*.gen.cfg
+
       - name: Set up Go
+        if: steps.filter.outputs.any_changed == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Check generated files
+        if: steps.filter.outputs.any_changed == 'true'
         run: make check-generate-api
 
+      - name: Skip
+        if: steps.filter.outputs.any_changed == 'false'
+        run: echo "No API changes, skipping check"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,10 +3,6 @@ name: E2E
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".github/workflows/check-*.yaml"
   workflow_dispatch:
 
 concurrency:
@@ -19,21 +15,37 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check for relevant changes
+        uses: tj-actions/changed-files@v47
+        id: filter
+        with:
+          files_ignore: |
+            **.md
+            docs/**
+            .github/workflows/check-*.yaml
+
       - name: Set up Go
+        if: steps.filter.outputs.any_changed == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
       - name: Start services
+        if: steps.filter.outputs.any_changed == 'true'
         run: docker compose up -d --build --wait
 
       - name: Run E2E tests
+        if: steps.filter.outputs.any_changed == 'true'
         run: make test-e2e
 
       - name: Show logs on failure
-        if: failure()
+        if: failure() && steps.filter.outputs.any_changed == 'true'
         run: docker compose logs
 
       - name: Stop services
-        if: always()
+        if: always() && steps.filter.outputs.any_changed == 'true'
         run: docker compose down -v
+
+      - name: Skip
+        if: steps.filter.outputs.any_changed == 'false'
+        run: echo "No relevant changes, skipping E2E tests"


### PR DESCRIPTION
`check`, `check-aep`, and `e2e` are workflows with path filters don't run when no relevant files change.
When these workflows are required status checks, PRs get stuck waiting indefinitely because GitHub expects a status that never arrives.

Uses `tj-actions/changed-files` to detect changes at runtime instead of at trigger time. The workflow always runs (satisfying the required check) but skips the actual verification when no relevant files changed.