### PR TITLE
Use shared workflows from dcm-project/shared-workflows

### DIFF
--- a/.github/workflows/check-aep.yaml
+++ b/.github/workflows/check-aep.yaml
@@ -6,26 +6,4 @@ on:
 
 jobs:
   check-aep:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for relevant changes
-        uses: tj-actions/changed-files@v47
-        id: filter
-        with:
-          files: |
-            api/**/openapi.yaml
-            .spectral.yaml
-
-      - name: Install Spectral
-        if: steps.filter.outputs.any_changed == 'true'
-        run: npm install -g @stoplight/spectral-cli
-
-      - name: Check AEP compliance
-        if: steps.filter.outputs.any_changed == 'true'
-        run: make check-aep
-
-      - name: Skip
-        if: steps.filter.outputs.any_changed == 'false'
-        run: echo "No API changes, skipping check"
+    uses: dcm-project/shared-workflows/.github/workflows/check-aep.yaml@main

--- a/.github/workflows/check-clean-commits.yaml
+++ b/.github/workflows/check-clean-commits.yaml
@@ -1,0 +1,9 @@
+name: Check Clean Commits
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-clean-commits:
+    uses: dcm-project/shared-workflows/.github/workflows/check-clean-commits.yaml@main

--- a/.github/workflows/check-generate.yaml
+++ b/.github/workflows/check-generate.yaml
@@ -6,28 +6,4 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for relevant changes
-        uses: tj-actions/changed-files@v47
-        id: filter
-        with:
-          files: |
-            api/**
-            **/*.gen.cfg
-
-      - name: Set up Go
-        if: steps.filter.outputs.any_changed == 'true'
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Check generated files
-        if: steps.filter.outputs.any_changed == 'true'
-        run: make check-generate-api
-
-      - name: Skip
-        if: steps.filter.outputs.any_changed == 'false'
-        run: echo "No API changes, skipping check"
+    uses: dcm-project/shared-workflows/.github/workflows/check-generate.yaml@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,18 +7,5 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: make build
-
-      - name: Test
-        run: make test
+  ci:
+    uses: dcm-project/shared-workflows/.github/workflows/go-ci.yaml@main


### PR DESCRIPTION
Replaces duplicated CI workflow code with calls to centralized reusable workflows from [dcm-project/shared-workflows](https://github.com/dcm-project/shared-workflows) repo.

Also add `check-clean-commits` workflow to enforce clean git history before merge.