### PR TITLE
Add build-push-quay workflow to push images to Quay

### DIFF
--- a/.github/workflows/build-push-quay.yaml
+++ b/.github/workflows/build-push-quay.yaml
@@ -1,0 +1,21 @@
+name: Build and Push Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to push (e.g. v1.0.0). When set, only this tag is used.'
+        required: false
+
+jobs:
+  build-push:
+    uses: dcm-project/shared-workflows/.github/workflows/build-push-quay.yaml@main
+    with:
+      image-name: service-provider-manager
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      quay-username: ${{ secrets.QUAY_USERNAME }}
+      quay-password: ${{ secrets.QUAY_PASSWORD }}


### PR DESCRIPTION
Adds a workflow that builds the container image and pushes it to quay.io/dcm-project/service-provider-manager.

Triggers:
- Push to main (tags: latest, sha-xxx)
- Push of version tags v* (tags: latest, sha-xxx, v1.0.0)
- Manual run (optional version input)
