### PR TITLE
Use QUAY_TOKEN instead of QUAY_PASSWORD

### DIFF
--- a/.github/workflows/build-push-quay.yaml
+++ b/.github/workflows/build-push-quay.yaml
@@ -18,4 +18,4 @@ jobs:
       version: ${{ github.event.inputs.version }}
     secrets:
       quay-username: ${{ secrets.QUAY_USERNAME }}
-      quay-password: ${{ secrets.QUAY_PASSWORD }}
+      quay-password: ${{ secrets.QUAY_TOKEN }}


### PR DESCRIPTION
Switches the build-push-quay workflow to use QUAY_TOKEN instead of QUAY_PASSWORD to match the existing org secrets.