### PR TITLE
ci: add gateway contract test workflow

### DIFF
--- a/.github/workflows/gateway-contract-test.yaml
+++ b/.github/workflows/gateway-contract-test.yaml
@@ -1,0 +1,16 @@
+name: Gateway Contract Test
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  contract-test:
+    uses: dcm-project/shared-workflows/.github/workflows/gateway-contract-test.yaml@main
+    with:
+      krakend-repo: dcm-project/api-gateway
+      krakend-config: config/krakend.json
+      override-spec: service-provider-manager=api/v1alpha1/openapi.yaml
+      service: service-provider-manager
+      watch-paths: |
+        api/**/openapi.yaml


### PR DESCRIPTION
Adds a caller workflow for the reusable gateway contract test defined in dcm-project/shared-workflows#8. On PRs that change OpenAPI specs, it validates that the API gateway's KrakenD routes are consistent with this service's spec.