### PR TITLE
Speed up tests: inject resty client and configurable DB retry for tests

### DIFF
--- a/cmd/service-provider-manager/main.go
+++ b/cmd/service-provider-manager/main.go
@@ -61,7 +61,7 @@ func run() int {
 	providerHandler := providerhandler.NewHandler(providerService)
 
 	// Resource Manager API
-	instanceService := rmsvc.NewInstanceService(dataStore)
+	instanceService := rmsvc.NewInstanceService(dataStore, nil)
 	rmHandler := rmhandlers.NewHandler(instanceService)
 
 	// Initialize StatusConsumer

--- a/internal/handlers/resource_manager/handler_test.go
+++ b/internal/handlers/resource_manager/handler_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	server "github.com/dcm-project/service-provider-manager/internal/api/server/resource_manager"
 	rmhandlers "github.com/dcm-project/service-provider-manager/internal/handlers/resource_manager"
 	rmsvc "github.com/dcm-project/service-provider-manager/internal/service/resource_manager"
 	"github.com/dcm-project/service-provider-manager/internal/store"
 	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,7 +60,9 @@ var _ = Describe("Resource Manager Handler", func() {
 		Expect(db.Create(&provider).Error).NotTo(HaveOccurred())
 
 		dataStore := store.NewStore(db)
-		instanceService := rmsvc.NewInstanceService(dataStore)
+		instanceService := rmsvc.NewInstanceService(dataStore, resty.New().
+			SetTimeout(5*time.Second).
+			SetRetryCount(0))
 		handler = rmhandlers.NewHandler(instanceService)
 		ctx = context.Background()
 	})

--- a/internal/service/resource_manager/service_type_instance.go
+++ b/internal/service/resource_manager/service_type_instance.go
@@ -23,16 +23,24 @@ type InstanceService struct {
 	httpClient *resty.Client
 }
 
-func NewInstanceService(store store.Store) *InstanceService {
-	client := resty.New().
+func defaultProviderHTTPClient() *resty.Client {
+	return resty.New().
 		SetTimeout(30 * time.Second).
 		SetRetryCount(3).
 		SetRetryWaitTime(2 * time.Second).
 		SetRetryMaxWaitTime(30 * time.Second)
+}
 
+// NewInstanceService constructs InstanceService. If httpClient is nil, production
+// defaults are used for outbound provider HTTP; tests may pass a non-nil client
+// (e.g. no retries, short timeout) to avoid slow failures.
+func NewInstanceService(store store.Store, httpClient *resty.Client) *InstanceService {
+	if httpClient == nil {
+		httpClient = defaultProviderHTTPClient()
+	}
 	return &InstanceService{
 		store:      store,
-		httpClient: client,
+		httpClient: httpClient,
 	}
 }
 

--- a/internal/service/resource_manager/service_type_instance_test.go
+++ b/internal/service/resource_manager/service_type_instance_test.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"github.com/dcm-project/service-provider-manager/api/v1alpha1/resource_manager"
 	"github.com/dcm-project/service-provider-manager/internal/service"
 	rmsvc "github.com/dcm-project/service-provider-manager/internal/service/resource_manager"
 	"github.com/dcm-project/service-provider-manager/internal/store"
 	"github.com/dcm-project/service-provider-manager/internal/store/model"
+	"github.com/go-resty/resty/v2"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,7 +70,9 @@ var _ = Describe("InstanceService", func() {
 		Expect(db.Create(&provider).Error).NotTo(HaveOccurred())
 
 		dataStore = store.NewStore(db)
-		instanceService = rmsvc.NewInstanceService(dataStore)
+		instanceService = rmsvc.NewInstanceService(dataStore, resty.New().
+			SetTimeout(5*time.Second).
+			SetRetryCount(0))
 		ctx = context.Background()
 	})
 

--- a/internal/store/resource_manager/service_instance.go
+++ b/internal/store/resource_manager/service_instance.go
@@ -45,13 +45,23 @@ type ServiceTypeInstance interface { //nolint:interfacebloat
 }
 
 type ServiceTypeInstanceStore struct {
-	db *gorm.DB
+	db        *gorm.DB
+	retryOpts []backoff.RetryOption
 }
 
 var _ ServiceTypeInstance = (*ServiceTypeInstanceStore)(nil)
 
-func NewServiceTypeInstance(db *gorm.DB) ServiceTypeInstance {
-	return &ServiceTypeInstanceStore{db: db}
+// NewServiceTypeInstance constructs the store. If no retry options are passed,
+// production backoff is used for Create and HardDelete. Tests may pass custom
+// options (e.g. sub-second intervals) to avoid slow retry exhaustion.
+func NewServiceTypeInstance(db *gorm.DB, retryOpts ...backoff.RetryOption) ServiceTypeInstance {
+	var opts []backoff.RetryOption
+	if len(retryOpts) == 0 {
+		opts = getRetryOptions()
+	} else {
+		opts = append([]backoff.RetryOption(nil), retryOpts...)
+	}
+	return &ServiceTypeInstanceStore{db: db, retryOpts: opts}
 }
 
 func (s *ServiceTypeInstanceStore) List(ctx context.Context, opts *ServiceTypeInstanceListOptions) (*ServiceTypeInstanceListResult, error) {
@@ -120,7 +130,7 @@ func (s *ServiceTypeInstanceStore) Create(ctx context.Context, instance model.Se
 		return &instance, nil
 	}
 
-	return backoff.Retry(ctx, operation, getRetryOptions()...)
+	return backoff.Retry(ctx, operation, s.retryOpts...)
 }
 
 func (s *ServiceTypeInstanceStore) Get(ctx context.Context, id string, showDeleted bool) (*model.ServiceTypeInstance, error) {
@@ -247,7 +257,7 @@ func (s *ServiceTypeInstanceStore) HardDelete(ctx context.Context, id string) er
 		return nil, nil
 	}
 
-	_, err := backoff.Retry(ctx, operation, getRetryOptions()...)
+	_, err := backoff.Retry(ctx, operation, s.retryOpts...)
 	return err
 }
 

--- a/internal/store/resource_manager/service_instance_test.go
+++ b/internal/store/resource_manager/service_instance_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/dcm-project/service-provider-manager/internal/store/model"
 	rmstore "github.com/dcm-project/service-provider-manager/internal/store/resource_manager"
+	"github.com/dcm-project/service-provider-manager/internal/testutil"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -46,7 +47,7 @@ var _ = Describe("ServiceTypeInstance Store", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(db.AutoMigrate(&model.ServiceTypeInstance{})).To(Succeed())
 
-		s = rmstore.NewServiceTypeInstance(db)
+		s = rmstore.NewServiceTypeInstance(db, testutil.FastServiceTypeInstanceRetry()...)
 		ctx = context.Background()
 	})
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@
 package store
 
 import (
+	"github.com/cenkalti/backoff/v5"
 	providerstore "github.com/dcm-project/service-provider-manager/internal/store/provider"
 	rmstore "github.com/dcm-project/service-provider-manager/internal/store/resource_manager"
 	"gorm.io/gorm"
@@ -19,11 +20,36 @@ type DataStore struct {
 	instance rmstore.ServiceTypeInstance
 }
 
-func NewStore(db *gorm.DB) Store {
+type storeConfig struct {
+	instanceRetry []backoff.RetryOption
+}
+
+// StoreOption configures NewStore.
+type StoreOption func(*storeConfig)
+
+// WithServiceTypeInstanceRetry sets backoff for service type instance Create/HardDelete.
+func WithServiceTypeInstanceRetry(opts ...backoff.RetryOption) StoreOption {
+	return func(c *storeConfig) {
+		c.instanceRetry = append([]backoff.RetryOption(nil), opts...)
+	}
+}
+
+// NewStore constructs the data store. Optional StoreOptions are for tests (e.g. fast DB retry).
+func NewStore(db *gorm.DB, opts ...StoreOption) Store {
+	cfg := &storeConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
+	var instance rmstore.ServiceTypeInstance
+	if len(cfg.instanceRetry) > 0 {
+		instance = rmstore.NewServiceTypeInstance(db, cfg.instanceRetry...)
+	} else {
+		instance = rmstore.NewServiceTypeInstance(db)
+	}
 	return &DataStore{
 		db:       db,
 		provider: providerstore.NewProvider(db),
-		instance: rmstore.NewServiceTypeInstance(db),
+		instance: instance,
 	}
 }
 

--- a/internal/testutil/backoff.go
+++ b/internal/testutil/backoff.go
@@ -1,0 +1,22 @@
+// Package testutil provides helpers shared by tests in this module.
+package testutil
+
+import (
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+)
+
+// FastServiceTypeInstanceRetry returns backoff.RetryOption values for tests that
+// construct the service-type-instance store (Create/HardDelete retry paths).
+// Delays stay in the millisecond range so retry exhaustion does not stall suites.
+func FastServiceTypeInstanceRetry() []backoff.RetryOption {
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = time.Millisecond
+	b.MaxInterval = time.Millisecond
+	b.Multiplier = 1.0
+	return []backoff.RetryOption{
+		backoff.WithBackOff(b),
+		backoff.WithMaxTries(4),
+	}
+}


### PR DESCRIPTION
## Why
Tests were spending a long time on failures that hit **HTTP retries** (resty) and **DB retries** (backoff around instance `Create` / `HardDelete`). 

Production defaults are right for real outages; in tests they mostly add wall-clock delay without adding signal.

## What
- Optional **`resty.Client`** on the instance service (`nil` → same behavior as before in production).
- Optional **retry options** on the service-type-instance store and **`NewStore`** helper for tests.
- Small **`internal/testutil`** helper for fast backoff in tests so suites stay quick.