### PR TITLE
Skip provider call for deferred deletion

### DIFF
--- a/internal/service/resource_manager/service_type_instance.go
+++ b/internal/service/resource_manager/service_type_instance.go
@@ -200,7 +200,7 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, instanceID string,
 			}
 		}
 
-		log.Info("Deferred deletion of instance from provider", "instance_id", instance.ID, "provider_name", instance.ProviderName)
+		log.Info("Scheduled deferred deletion of instance from provider", "instance_id", instance.ID, "provider_name", instance.ProviderName)
 		return nil
 	}
 

--- a/internal/service/resource_manager/service_type_instance.go
+++ b/internal/service/resource_manager/service_type_instance.go
@@ -170,8 +170,8 @@ func (s *InstanceService) ListInstances(ctx context.Context, providerName *strin
 	return apiResult, nil
 }
 
-// DeleteInstance removes an instance by ID. When deferred is true, deletion
-// failures are recorded in a cleanup queue and the method returns success.
+// DeleteInstance removes an instance by ID. When deferred is true, the instance
+// is marked for background cleanup without contacting the provider.
 func (s *InstanceService) DeleteInstance(ctx context.Context, instanceID string, deferred bool) error {
 	log := logging.FromContext(ctx)
 	log.Debug("Deleting instance", "instance_id", instanceID, "deferred", deferred)
@@ -186,7 +186,25 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, instanceID string,
 		return service.NewInternalError(fmt.Sprintf("failed to retrieve instance: %v", err))
 	}
 
-	// Attempt SP deletion and DB hard-delete
+	// Deferred mode: skip provider call, just enqueue for background cleanup
+	if deferred {
+		if instance.DeletionStatus != nil {
+			// Already marked — reset retry count so scheduler picks it up again
+			if resetErr := s.store.ServiceTypeInstance().ResetRetryCount(ctx, instanceID); resetErr != nil {
+				log.Error("Failed to reset retry count for instance", "instance_id", instanceID, "error", resetErr)
+			}
+		} else {
+			// Mark as pending deletion
+			if markErr := s.store.ServiceTypeInstance().MarkForDeletion(ctx, instanceID); markErr != nil {
+				return service.NewInternalError(fmt.Sprintf("failed to mark instance %s for deletion: %v", instanceID, markErr))
+			}
+		}
+
+		log.Info("Deferred deletion of instance from provider", "instance_id", instance.ID, "provider_name", instance.ProviderName)
+		return nil
+	}
+
+	// Non-deferred: attempt SP deletion and DB hard-delete
 	deleteErr := s.DeleteFromProvider(ctx, instance)
 	if deleteErr == nil {
 		return nil
@@ -199,32 +217,13 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, instanceID string,
 		"error", deleteErr,
 	)
 
-	// SP deletion failed
-	if !deferred {
-		// For already-pending/failed instances, reset retry count so scheduler picks it up again
-		if instance.DeletionStatus != nil {
-			if resetErr := s.store.ServiceTypeInstance().ResetRetryCount(ctx, instanceID); resetErr != nil {
-				log.Error("Failed to reset retry count for instance", "instance_id", instanceID, "error", resetErr)
-			}
-		}
-		return service.NewProviderError(fmt.Sprintf("failed to delete instance (%s): %v", instanceID, deleteErr))
-	}
-
-	// Deferred mode: mark for deletion (or reset retry count if already pending/failed)
+	// For already-pending/failed instances, reset retry count so scheduler picks it up again
 	if instance.DeletionStatus != nil {
-		// Already marked — reset retry count for FAILED instances
 		if resetErr := s.store.ServiceTypeInstance().ResetRetryCount(ctx, instanceID); resetErr != nil {
 			log.Error("Failed to reset retry count for instance", "instance_id", instanceID, "error", resetErr)
 		}
-	} else {
-		// Mark as pending deletion
-		if markErr := s.store.ServiceTypeInstance().MarkForDeletion(ctx, instanceID); markErr != nil {
-			return service.NewInternalError(fmt.Sprintf("failed to mark instance %s for deletion: %v", instanceID, markErr))
-		}
 	}
-
-	log.Info("Deferred deletion of instance from provider", "instance_id", instance.ID, "provider_name", instance.ProviderName)
-	return nil
+	return service.NewProviderError(fmt.Sprintf("failed to delete instance (%s): %v", instanceID, deleteErr))
 }
 
 // DeleteFromProvider deletes the instance from its service provider and, on

--- a/internal/service/resource_manager/service_type_instance_test.go
+++ b/internal/service/resource_manager/service_type_instance_test.go
@@ -506,19 +506,17 @@ var _ = Describe("InstanceService", func() {
 			Expect(svcErr.Code).To(Equal(service.ErrCodeProviderError))
 		})
 
-		It("defers deletion when provider is missing and deferred is true", func() {
+		It("defers deletion without contacting provider", func() {
 			req := &resource_manager.ServiceTypeInstance{
 				ProviderName: "test-provider",
 				Spec:         map[string]interface{}{"cpu": 2},
 			}
 			created, _ := instanceService.CreateInstance(ctx, req, nil)
 
-			// Delete the provider from the database
-			Expect(db.Delete(&model.Provider{}, "name = ?", "test-provider").Error).NotTo(HaveOccurred())
-
-			// Deferred delete should succeed
+			// Deferred delete should succeed without calling the provider
 			err := instanceService.DeleteInstance(ctx, *created.Id, true)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteRequested).To(BeFalse())
 
 			// Instance should be marked for deletion, not visible in default list
 			result, err := instanceService.ListInstances(ctx, nil, false, nil, nil)
@@ -532,46 +530,26 @@ var _ = Describe("InstanceService", func() {
 			Expect(string(*(*result.Instances)[0].DeletionStatus)).To(Equal("PENDING"))
 		})
 
-		It("defers deletion when provider returns error and deferred is true", func() {
-			// Create a provider that returns errors on delete
-			mockProviderError := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method == http.MethodDelete {
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_ = json.NewEncoder(w).Encode(map[string]string{
-					"id":     uuid.New().String(),
-					"status": "PROVISIONING",
-				})
-			}))
-			defer mockProviderError.Close()
-
-			errorProvider := model.Provider{
-				ID:           uuid.New().String(),
-				Name:         "error-provider",
-				ServiceType:  "vm",
-				Endpoint:     mockProviderError.URL,
-				HealthStatus: model.HealthStatusReady,
-			}
-			Expect(db.Create(&errorProvider).Error).NotTo(HaveOccurred())
-
+		It("defers deletion without contacting provider even when provider is missing", func() {
 			req := &resource_manager.ServiceTypeInstance{
-				ProviderName: "error-provider",
+				ProviderName: "test-provider",
 				Spec:         map[string]interface{}{"cpu": 2},
 			}
-			created, err := instanceService.CreateInstance(ctx, req, nil)
-			Expect(err).NotTo(HaveOccurred())
+			created, _ := instanceService.CreateInstance(ctx, req, nil)
 
-			// Deferred delete should succeed despite provider error
-			err = instanceService.DeleteInstance(ctx, *created.Id, true)
+			// Delete the provider from the database
+			Expect(db.Delete(&model.Provider{}, "name = ?", "test-provider").Error).NotTo(HaveOccurred())
+
+			// Deferred delete should succeed without attempting provider call
+			err := instanceService.DeleteInstance(ctx, *created.Id, true)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteRequested).To(BeFalse())
 
 			// Verify marked as PENDING
 			result, err := instanceService.ListInstances(ctx, nil, true, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*result.Instances).To(HaveLen(1))
+			Expect(string(*(*result.Instances)[0].DeletionStatus)).To(Equal("PENDING"))
 		})
 
 		It("resets retry count when deleting a FAILED instance with deferred=true", func() {
@@ -588,12 +566,10 @@ var _ = Describe("InstanceService", func() {
 				"retry_count":     10,
 			}).Error).NotTo(HaveOccurred())
 
-			// Delete the provider so SP deletion fails
-			Expect(db.Delete(&model.Provider{}, "name = ?", "test-provider").Error).NotTo(HaveOccurred())
-
-			// Deferred delete should succeed and reset retry count
+			// Deferred delete should succeed and reset retry count without contacting provider
 			err := instanceService.DeleteInstance(ctx, *created.Id, true)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteRequested).To(BeFalse())
 
 			// Verify retry count was reset and status is PENDING
 			var instance model.ServiceTypeInstance

--- a/test/e2e/service_instance_test.go
+++ b/test/e2e/service_instance_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Service Instance API", func() {
 			Expect(*getResp.JSON200.DeletionStatus).To(Equal(resource_manager.PENDING))
 		})
 
-		It("hard-deletes on deferred delete when SP succeeds", func() {
+		It("marks instance PENDING on deferred delete even when SP is available", func() {
 			createInstance()
 
 			deferred := true
@@ -362,13 +362,14 @@ var _ = Describe("Service Instance API", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(deleteResp.StatusCode()).To(Equal(http.StatusNoContent))
 
-			// Instance should be fully removed, not even visible with show_deleted
+			// Instance should be marked PENDING, not hard-deleted
 			showDeleted := true
 			getResp, err := rmApiClient.GetInstanceWithResponse(ctx, instID, &resource_manager.GetInstanceParams{
 				ShowDeleted: &showDeleted,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(getResp.StatusCode()).To(Equal(http.StatusNotFound))
+			Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(string(*getResp.JSON200.DeletionStatus)).To(Equal("PENDING"))
 		})
 
 		It("excludes soft-deleted instances from default LIST", func() {


### PR DESCRIPTION
## What
Deferred delete now immediately enqueues the instance for background cleanup without attempting to contact the service provider.

## Why
Deferred deletion exists for cases where the provider may be unavailable. The previous implementation tried the provider first, which could block on a timeout before falling back to the cleanup queue.

## Changes
- Move the deferred check before the provider call in DeleteInstance, so deferred=true skips DeleteFromProvider entirely and marks the instance as PENDING immediately
- Simplify the non-deferred error path now that it no longer shares code with the deferred path
- Update tests to assert the provider is not contacted when deferred=true
- Remove unnecessary error-provider mock setup from deferred deletion tests

## Testing
Updated service-layer unit tests to verify the provider delete endpoint is not called in deferred mode, including cases with available providers, missing providers, and FAILED instances.