### PR TITLE
Persist provider status field in the data model

### DIFF
--- a/internal/handlers/provider/handler_test.go
+++ b/internal/handlers/provider/handler_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Handler", func() {
 			Expect(*jsonResp.Providers).To(BeEmpty())
 		})
 
-		It("returns providers", func() {
+		It("returns providers with status", func() {
 			// Create providers first
 			for _, name := range []string{"provider-1", "provider-2"} {
 				createReq := providerserver.CreateProviderRequestObject{
@@ -160,11 +160,15 @@ var _ = Describe("Handler", func() {
 			jsonResp, ok := resp.(providerserver.ListProviders200JSONResponse)
 			Expect(ok).To(BeTrue())
 			Expect(*jsonResp.Providers).To(HaveLen(2))
+			for _, p := range *jsonResp.Providers {
+				Expect(p.Status).NotTo(BeNil())
+				Expect(*p.Status).To(Equal(providerserver.Registered))
+			}
 		})
 	})
 
 	Describe("GetProvider", func() {
-		It("returns provider", func() {
+		It("returns provider with status", func() {
 			// Create a provider first
 			createReq := providerserver.CreateProviderRequestObject{
 				Body: &providerserver.Provider{
@@ -187,6 +191,8 @@ var _ = Describe("Handler", func() {
 			jsonResp, ok := resp.(providerserver.GetProvider200JSONResponse)
 			Expect(ok).To(BeTrue())
 			Expect(jsonResp.Name).To(Equal("get-me"))
+			Expect(jsonResp.Status).NotTo(BeNil())
+			Expect(*jsonResp.Status).To(Equal(providerserver.Registered))
 		})
 
 		It("returns 404 for non-existent provider", func() {
@@ -203,7 +209,7 @@ var _ = Describe("Handler", func() {
 	})
 
 	Describe("ApplyProvider", func() {
-		It("updates existing provider", func() {
+		It("updates existing provider with status updated", func() {
 			// Create a provider first
 			createReq := providerserver.CreateProviderRequestObject{
 				Body: &providerserver.Provider{
@@ -234,6 +240,8 @@ var _ = Describe("Handler", func() {
 			jsonResp, ok := resp.(providerserver.ApplyProvider200JSONResponse)
 			Expect(ok).To(BeTrue())
 			Expect(jsonResp.Endpoint).To(Equal("https://updated.example.com"))
+			Expect(jsonResp.Status).NotTo(BeNil())
+			Expect(*jsonResp.Status).To(Equal(providerserver.Updated))
 		})
 
 		It("returns 404 for non-existent provider", func() {

--- a/internal/service/provider/convert.go
+++ b/internal/service/provider/convert.go
@@ -10,6 +10,7 @@ import (
 
 // ModelToProvider converts a database model to an API response type.
 func ModelToProvider(m *model.Provider) *providerserver.Provider {
+	status := providerserver.ProviderStatus(m.Status)
 	p := &providerserver.Provider{
 		Id:            &m.ID,
 		Name:          m.Name,
@@ -17,6 +18,7 @@ func ModelToProvider(m *model.Provider) *providerserver.Provider {
 		SchemaVersion: m.SchemaVersion,
 		Endpoint:      m.Endpoint,
 		DisplayName:   m.DisplayName,
+		Status:        &status,
 		HealthStatus:  m.HealthStatus.StringPtr(),
 		CreateTime:    service.PtrTime(m.CreateTime),
 		UpdateTime:    service.PtrTime(m.UpdateTime),
@@ -39,13 +41,6 @@ func ModelToProvider(m *model.Provider) *providerserver.Provider {
 	return p
 }
 
-// ModelToProviderWithStatus converts a database model to an API response with status.
-func ModelToProviderWithStatus(m *model.Provider, status providerserver.ProviderStatus) *providerserver.Provider {
-	p := ModelToProvider(m)
-	p.Status = &status
-	return p
-}
-
 // ProviderToModel converts an API request to a database model.
 func ProviderToModel(req *providerserver.Provider, id string) model.Provider {
 	m := model.Provider{
@@ -55,6 +50,7 @@ func ProviderToModel(req *providerserver.Provider, id string) model.Provider {
 		SchemaVersion: req.SchemaVersion,
 		Endpoint:      req.Endpoint,
 		DisplayName:   req.DisplayName,
+		Status:        string(providerserver.Registered),
 	}
 	if req.Metadata != nil {
 		if metaMap, err := providerMetadataToMap(req.Metadata); err == nil {
@@ -73,6 +69,7 @@ func applyProviderRequestToModel(dest *model.Provider, req *providerserver.Provi
 	dest.SchemaVersion = req.SchemaVersion
 	dest.Endpoint = req.Endpoint
 	dest.DisplayName = req.DisplayName
+	dest.Status = string(providerserver.Updated)
 	dest.Metadata = nil
 	if req.Metadata != nil {
 		if metaMap, err := providerMetadataToMap(req.Metadata); err == nil {

--- a/internal/service/provider/provider.go
+++ b/internal/service/provider/provider.go
@@ -59,7 +59,7 @@ func (s *ProviderService) RegisterOrUpdateProvider(ctx context.Context, req *pro
 		if err != nil {
 			return nil, err
 		}
-		return ModelToProviderWithStatus(updated, providerserver.Updated), nil
+		return ModelToProvider(updated), nil
 	}
 
 	providerID, err := s.resolveProviderID(ctx, requestedID)
@@ -75,7 +75,7 @@ func (s *ProviderService) RegisterOrUpdateProvider(ctx context.Context, req *pro
 	}
 
 	log.Info("Provider created", "provider_id", created.ID, "name", created.Name)
-	return ModelToProviderWithStatus(created, providerserver.Registered), nil
+	return ModelToProvider(created), nil
 }
 
 // parseProviderID extracts the provider ID from request body or query parameter.

--- a/internal/service/provider/provider_test.go
+++ b/internal/service/provider/provider_test.go
@@ -210,6 +210,17 @@ var _ = Describe("ProviderService", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(provider.Name).To(Equal("get-test"))
+			Expect(provider.Status).NotTo(BeNil())
+			Expect(*provider.Status).To(Equal(providerserver.Registered))
+
+			// Re-register to trigger update, then verify status via Get
+			req.Id = resp.Id
+			_, err = providerService.RegisterOrUpdateProvider(ctx, req, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			provider, err = providerService.GetProvider(ctx, *resp.Id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*provider.Status).To(Equal(providerserver.Updated))
 		})
 
 		It("returns error for non-existent provider", func() {
@@ -224,15 +235,29 @@ var _ = Describe("ProviderService", func() {
 
 	Describe("ListProviders", func() {
 		It("returns all providers", func() {
-			_, err := providerService.RegisterOrUpdateProvider(ctx, newProvider("p1"), nil)
+			resp1, err := providerService.RegisterOrUpdateProvider(ctx, newProvider("p1"), nil)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = providerService.RegisterOrUpdateProvider(ctx, newProvider("p2"), nil)
+
+			// Re-register p2 so its status becomes "updated"
+			req2 := newProvider("p2")
+			resp2, err := providerService.RegisterOrUpdateProvider(ctx, req2, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req2.Id = resp2.Id
+			_, err = providerService.RegisterOrUpdateProvider(ctx, req2, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			result, err := providerService.ListProviders(ctx, "", 0, "")
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Providers).To(HaveLen(2))
+
+			statusByID := map[string]providerserver.ProviderStatus{}
+			for _, p := range result.Providers {
+				Expect(p.Status).NotTo(BeNil())
+				statusByID[*p.Id] = *p.Status
+			}
+			Expect(statusByID[*resp1.Id]).To(Equal(providerserver.Registered))
+			Expect(statusByID[*resp2.Id]).To(Equal(providerserver.Updated))
 		})
 
 		It("filters by service type", func() {
@@ -329,6 +354,8 @@ var _ = Describe("ProviderService", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updated.Endpoint).To(Equal("https://updated.example.com"))
+			Expect(updated.Status).NotTo(BeNil())
+			Expect(*updated.Status).To(Equal(providerserver.Updated))
 		})
 
 		It("returns conflict when renaming to existing name", func() {

--- a/internal/store/model/provider.go
+++ b/internal/store/model/provider.go
@@ -29,6 +29,7 @@ type Provider struct {
 	DisplayName   *string                `gorm:"column:display_name"`
 	Operations    []string               `gorm:"column:operations;serializer:json"`
 	Metadata      map[string]interface{} `gorm:"column:metadata;serializer:json"`
+	Status        string                 `gorm:"column:status;not null;default:registered"`
 	CreateTime    time.Time              `gorm:"column:create_time;autoCreateTime"`
 	UpdateTime    time.Time              `gorm:"column:update_time;autoUpdateTime"`
 

--- a/internal/store/provider/provider.go
+++ b/internal/store/provider/provider.go
@@ -122,7 +122,7 @@ func (s *ProviderStore) Update(ctx context.Context, provider model.Provider) (*m
 	result := s.db.WithContext(ctx).Model(&provider).Clauses(clause.Returning{}).
 		Select(
 			"Name", "ServiceType", "SchemaVersion", "Endpoint",
-			"DisplayName", "Operations", "Metadata", "UpdateTime",
+			"DisplayName", "Operations", "Metadata", "Status", "UpdateTime",
 		).Updates(&provider)
 	if result.Error != nil {
 		return nil, result.Error


### PR DESCRIPTION
## What
Add the `status` field (registered/updated) to the provider data model so it is persisted and returned in all API responses.

## Why
The OpenAPI spec defines a read-only `status` field on the Provider schema, but the value was only computed transiently during registration and never stored. As a result, GET, List, and PUT responses omitted the field entirely.

## Changes
- Added `Status` field to the provider database model with a default of `registered`
- Updated model-to-API conversion to read status from the persisted model
- Set status to `registered` on creation and `updated` on any modification
- Added `Status` to the explicit column select list in the store update method
- Removed the now-unnecessary `ModelToProviderWithStatus` helper

## Testing
Added status assertions to existing service and handler tests for Get, List, and Update operations, verifying both `registered` and `updated` status values are correctly persisted and returned.