### PR TITLE
Add three-state health model for service providers

### DIFF
--- a/internal/cleanup/scheduler_test.go
+++ b/internal/cleanup/scheduler_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Scheduler", func() {
 		It("skips instance when provider is not ready", func() {
 			// Mark provider as NotReady
 			Expect(db.Model(&model.Provider{}).Where("name = ?", providerName).
-				Update("health_status", model.HealthStatusNotReady).Error).NotTo(HaveOccurred())
+				Update("health_status", model.HealthStatusUnavailable).Error).NotTo(HaveOccurred())
 
 			// Create an instance marked for deletion
 			inst := model.ServiceTypeInstance{
@@ -102,6 +102,27 @@ var _ = Describe("Scheduler", func() {
 			scheduler.ProcessPendingDeletions(ctx)
 
 			// Instance should be marked as PENDING_PROVIDER, not deleted
+			found, err := dataStore.ServiceTypeInstance().Get(ctx, inst.ID, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*found.DeletionStatus).To(Equal("PENDING_PROVIDER"))
+		})
+
+		It("skips instance when provider is unhealthy", func() {
+			Expect(db.Model(&model.Provider{}).Where("name = ?", providerName).
+				Update("health_status", model.HealthStatusUnhealthy).Error).NotTo(HaveOccurred())
+
+			inst := model.ServiceTypeInstance{
+				ID:           uuid.New().String(),
+				ProviderName: providerName,
+				Status:       "PROVISIONING",
+				InstanceName: "skip-unhealthy-inst",
+				Spec:         map[string]any{"cpu": 1},
+			}
+			Expect(db.Create(&inst).Error).NotTo(HaveOccurred())
+			Expect(dataStore.ServiceTypeInstance().MarkForDeletion(ctx, inst.ID)).To(Succeed())
+
+			scheduler.ProcessPendingDeletions(ctx)
+
 			found, err := dataStore.ServiceTypeInstance().Get(ctx, inst.ID, true)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(*found.DeletionStatus).To(Equal("PENDING_PROVIDER"))

--- a/internal/healthcheck/monitor.go
+++ b/internal/healthcheck/monitor.go
@@ -3,6 +3,7 @@ package healthcheck
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"math"
 	"net/http"
@@ -15,6 +16,18 @@ import (
 	providerstore "github.com/dcm-project/service-provider-manager/internal/store/provider"
 	rmstore "github.com/dcm-project/service-provider-manager/internal/store/resource_manager"
 )
+
+type healthCheckResult int
+
+const (
+	healthCheckHealthy healthCheckResult = iota
+	healthCheckUnhealthy
+	healthCheckFailed
+)
+
+type healthResponse struct {
+	Status string `json:"status"`
+}
 
 // Monitor performs periodic health checks on registered service providers
 type Monitor struct {
@@ -99,16 +112,22 @@ func (m *Monitor) CheckProviders(ctx context.Context) {
 
 func (m *Monitor) checkProvider(ctx context.Context, provider model.Provider) {
 	now := time.Now()
-	newStatus := model.HealthStatusReady
-	consecutiveFailures := 0
+	var newStatus model.HealthStatus
+	var consecutiveFailures int
 
-	healthy := m.performHealthCheck(ctx, provider)
-	if !healthy {
+	result := m.performHealthCheck(ctx, provider)
+	switch result {
+	case healthCheckHealthy:
+		newStatus = model.HealthStatusReady
+		consecutiveFailures = 0
+	case healthCheckUnhealthy:
+		newStatus = model.HealthStatusUnhealthy
+		consecutiveFailures = 0
+	case healthCheckFailed:
 		consecutiveFailures = provider.ConsecutiveFailures + 1
-
 		newStatus = provider.HealthStatus
 		if consecutiveFailures >= m.maxConsecutiveFailures {
-			newStatus = model.HealthStatusNotReady
+			newStatus = model.HealthStatusUnavailable
 		}
 	}
 
@@ -126,7 +145,7 @@ func (m *Monitor) checkProvider(ctx context.Context, provider model.Provider) {
 		)
 
 		switch newStatus {
-		case model.HealthStatusNotReady:
+		case model.HealthStatusUnhealthy, model.HealthStatusUnavailable:
 			if err := m.instanceStore.MarkProviderDeletionsPendingProvider(ctx, provider.Name); err != nil {
 				slog.Error("Failed to park deletions for unhealthy provider", "provider", provider.Name, "error", err)
 			}
@@ -138,36 +157,50 @@ func (m *Monitor) checkProvider(ctx context.Context, provider model.Provider) {
 	}
 }
 
-func (m *Monitor) performHealthCheck(ctx context.Context, provider model.Provider) bool {
+func (m *Monitor) performHealthCheck(ctx context.Context, provider model.Provider) healthCheckResult {
 	healthURL := strings.TrimRight(provider.Endpoint, "/") + "/health"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, nil)
 	if err != nil {
 		slog.Error("Error creating health check request", "provider", provider.Name, "error", err)
-		return false
+		return healthCheckFailed
 	}
 
 	resp, err := m.httpClient.Do(req)
 	if err != nil {
 		slog.Debug("Health check failed", "provider", provider.Name, "error", err)
-		return false
+		return healthCheckFailed
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return true
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		slog.Debug("Health check failed", "provider", provider.Name, "status_code", resp.StatusCode)
+		return healthCheckFailed
 	}
 
-	slog.Debug("Health check failed", "provider", provider.Name, "status_code", resp.StatusCode)
-	return false
+	var hr healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&hr); err != nil {
+		slog.Error("Error parsing health check response", "provider", provider.Name, "error", err)
+		return healthCheckFailed
+	}
+
+	switch hr.Status {
+	case "healthy":
+		return healthCheckHealthy
+	case "unhealthy":
+		slog.Debug("Provider reports unhealthy backing provider", "provider", provider.Name)
+		return healthCheckUnhealthy
+	default:
+		slog.Debug("Unknown health status in response", "provider", provider.Name, "status", hr.Status)
+		return healthCheckFailed
+	}
 }
 
 // CalculateNextCheckTime determines when the next health check should occur
-// For Ready providers: standard interval (10 seconds)
-// Exponential backoff for NotReady providers
+// For Ready and Unhealthy providers: standard interval (provider is reachable)
+// Exponential backoff for Unavailable providers
 // Formula: min(MaxBackoff, BaseInterval * 2^(failures - MaxConsecutiveFailures))
-// This starts exponential backoff after the provider becomes NotReady
 func (m *Monitor) CalculateNextCheckTime(now time.Time, status model.HealthStatus, consecutiveFailures int) time.Time {
-	if status == model.HealthStatusReady {
+	if status != model.HealthStatusUnavailable {
 		return now.Add(m.interval)
 	}
 

--- a/internal/healthcheck/monitor_test.go
+++ b/internal/healthcheck/monitor_test.go
@@ -2,6 +2,7 @@ package healthcheck_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"time"
@@ -161,6 +162,32 @@ func (m *mockInstanceStore) MarkDeletionFailed(_ context.Context, _ string) erro
 func (m *mockInstanceStore) HardDelete(_ context.Context, _ string) error             { return nil }
 func (m *mockInstanceStore) ResetRetryCount(_ context.Context, _ string) error        { return nil }
 
+func healthyServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, `{"status":"healthy"}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func unhealthyServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"status":"unhealthy"}`)
+	}))
+}
+
+func failingServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+}
+
 var _ = Describe("Monitor", func() {
 	var (
 		cfg     *config.HealthCheckConfig
@@ -186,7 +213,19 @@ var _ = Describe("Monitor", func() {
 			})
 		})
 
-		Context("for a NotReady provider with exponential backoff", func() {
+		Context("for an Unhealthy provider", func() {
+			It("schedules next check at the configured interval", func() {
+				mockStore := &mockProviderStore{}
+				monitor = healthcheck.NewMonitor(mockStore, &mockInstanceStore{}, cfg)
+				now := time.Now()
+
+				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusUnhealthy, 0)
+
+				Expect(nextCheck.Sub(now)).To(Equal(cfg.Interval))
+			})
+		})
+
+		Context("for an Unavailable provider with exponential backoff", func() {
 			var (
 				mockStore *mockProviderStore
 				now       time.Time
@@ -198,23 +237,23 @@ var _ = Describe("Monitor", func() {
 				now = time.Now()
 			})
 
-			It("uses base backoff interval when just became NotReady (3 failures)", func() {
-				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusNotReady, 3)
+			It("uses base backoff interval when just became Unavailable (3 failures)", func() {
+				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusUnavailable, 3)
 				Expect(nextCheck.Sub(now)).To(Equal(cfg.BaseBackoffInterval))
 			})
 
 			It("doubles backoff for 4 consecutive failures", func() {
-				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusNotReady, 4)
+				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusUnavailable, 4)
 				Expect(nextCheck.Sub(now)).To(Equal(cfg.BaseBackoffInterval * 2))
 			})
 
 			It("quadruples backoff for 5 consecutive failures", func() {
-				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusNotReady, 5)
+				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusUnavailable, 5)
 				Expect(nextCheck.Sub(now)).To(Equal(cfg.BaseBackoffInterval * 4))
 			})
 
 			It("caps backoff at max interval for many failures", func() {
-				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusNotReady, 100)
+				nextCheck := monitor.CalculateNextCheckTime(now, model.HealthStatusUnavailable, 100)
 				Expect(nextCheck.Sub(now)).To(Equal(cfg.MaxBackoffInterval))
 			})
 		})
@@ -223,13 +262,7 @@ var _ = Describe("Monitor", func() {
 	Describe("CheckProviders", func() {
 		Context("with a healthy provider", func() {
 			It("sets status to Ready with zero consecutive failures", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					if r.URL.Path == "/health" {
-						w.WriteHeader(http.StatusOK)
-						return
-					}
-					w.WriteHeader(http.StatusNotFound)
-				}))
+				server := healthyServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -254,22 +287,19 @@ var _ = Describe("Monitor", func() {
 			})
 		})
 
-		Context("with an unhealthy provider", func() {
-			It("becomes NotReady after reaching max consecutive failures", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+		Context("with a provider reporting unhealthy backing provider", func() {
+			It("transitions to Unhealthy immediately", func() {
+				server := unhealthyServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
 				mockStore := &mockProviderStore{
 					providers: model.ProviderList{
 						{
-							ID:                  providerID,
-							Name:                "test-provider",
-							Endpoint:            server.URL,
-							HealthStatus:        model.HealthStatusReady,
-							ConsecutiveFailures: 2, // Already 2 failures, this will be the 3rd
+							ID:           providerID,
+							Name:         "test-provider",
+							Endpoint:     server.URL,
+							HealthStatus: model.HealthStatusReady,
 						},
 					},
 				}
@@ -279,14 +309,14 @@ var _ = Describe("Monitor", func() {
 
 				Expect(mockStore.healthStatusUpdates).To(HaveLen(1))
 				update := mockStore.healthStatusUpdates[0]
-				Expect(update.Status).To(Equal(model.HealthStatusNotReady))
-				Expect(update.ConsecutiveFailures).To(Equal(3))
+				Expect(update.Status).To(Equal(model.HealthStatusUnhealthy))
+				Expect(update.ConsecutiveFailures).To(Equal(0))
 			})
+		})
 
-			It("stays Ready until reaching max consecutive failures", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+		Context("with a failing provider", func() {
+			It("becomes Unavailable after reaching max consecutive failures", func() {
+				server := failingServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -297,7 +327,33 @@ var _ = Describe("Monitor", func() {
 							Name:                "test-provider",
 							Endpoint:            server.URL,
 							HealthStatus:        model.HealthStatusReady,
-							ConsecutiveFailures: 1, // Only 1 failure so far
+							ConsecutiveFailures: 2,
+						},
+					},
+				}
+
+				monitor = healthcheck.NewMonitor(mockStore, &mockInstanceStore{}, cfg)
+				monitor.CheckProviders(ctx)
+
+				Expect(mockStore.healthStatusUpdates).To(HaveLen(1))
+				update := mockStore.healthStatusUpdates[0]
+				Expect(update.Status).To(Equal(model.HealthStatusUnavailable))
+				Expect(update.ConsecutiveFailures).To(Equal(3))
+			})
+
+			It("stays Ready until reaching max consecutive failures", func() {
+				server := failingServer()
+				defer server.Close()
+
+				providerID := uuid.New().String()
+				mockStore := &mockProviderStore{
+					providers: model.ProviderList{
+						{
+							ID:                  providerID,
+							Name:                "test-provider",
+							Endpoint:            server.URL,
+							HealthStatus:        model.HealthStatusReady,
+							ConsecutiveFailures: 1,
 						},
 					},
 				}
@@ -313,10 +369,8 @@ var _ = Describe("Monitor", func() {
 		})
 
 		Context("with a recovered provider", func() {
-			It("resets to Ready with zero consecutive failures", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
+			It("resets Unavailable provider to Ready with zero consecutive failures", func() {
+				server := healthyServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -326,8 +380,33 @@ var _ = Describe("Monitor", func() {
 							ID:                  providerID,
 							Name:                "test-provider",
 							Endpoint:            server.URL,
-							HealthStatus:        model.HealthStatusNotReady,
-							ConsecutiveFailures: 5, // Was failing, now healthy
+							HealthStatus:        model.HealthStatusUnavailable,
+							ConsecutiveFailures: 5,
+						},
+					},
+				}
+
+				monitor = healthcheck.NewMonitor(mockStore, &mockInstanceStore{}, cfg)
+				monitor.CheckProviders(ctx)
+
+				Expect(mockStore.healthStatusUpdates).To(HaveLen(1))
+				update := mockStore.healthStatusUpdates[0]
+				Expect(update.Status).To(Equal(model.HealthStatusReady))
+				Expect(update.ConsecutiveFailures).To(Equal(0))
+			})
+
+			It("resets Unhealthy provider to Ready with zero consecutive failures", func() {
+				server := healthyServer()
+				defer server.Close()
+
+				providerID := uuid.New().String()
+				mockStore := &mockProviderStore{
+					providers: model.ProviderList{
+						{
+							ID:           providerID,
+							Name:         "test-provider",
+							Endpoint:     server.URL,
+							HealthStatus: model.HealthStatusUnhealthy,
 						},
 					},
 				}
@@ -343,10 +422,8 @@ var _ = Describe("Monitor", func() {
 		})
 
 		Context("deletion status transitions on provider health change", func() {
-			It("calls MarkProviderDeletionsPendingProvider when provider transitions Ready -> NotReady", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+			It("calls MarkProviderDeletionsPendingProvider when provider transitions Ready -> Unavailable", func() {
+				server := failingServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -354,10 +431,35 @@ var _ = Describe("Monitor", func() {
 					providers: model.ProviderList{
 						{
 							ID:                  providerID,
-							Name:                "unhealthy-provider",
+							Name:                "failing-provider",
 							Endpoint:            server.URL,
 							HealthStatus:        model.HealthStatusReady,
-							ConsecutiveFailures: 2, // This will be the 3rd failure -> NotReady
+							ConsecutiveFailures: 2,
+						},
+					},
+				}
+
+				instStore := &mockInstanceStore{}
+				monitor = healthcheck.NewMonitor(mockStore, instStore, cfg)
+				monitor.CheckProviders(ctx)
+
+				Expect(instStore.markProviderDeletionsCalls).To(HaveLen(1))
+				Expect(instStore.markProviderDeletionsCalls[0]).To(Equal("failing-provider"))
+				Expect(instStore.reactivateProviderCalls).To(BeEmpty())
+			})
+
+			It("calls MarkProviderDeletionsPendingProvider when provider transitions Ready -> Unhealthy", func() {
+				server := unhealthyServer()
+				defer server.Close()
+
+				providerID := uuid.New().String()
+				mockStore := &mockProviderStore{
+					providers: model.ProviderList{
+						{
+							ID:           providerID,
+							Name:         "unhealthy-provider",
+							Endpoint:     server.URL,
+							HealthStatus: model.HealthStatusReady,
 						},
 					},
 				}
@@ -371,10 +473,8 @@ var _ = Describe("Monitor", func() {
 				Expect(instStore.reactivateProviderCalls).To(BeEmpty())
 			})
 
-			It("calls ReactivateProviderDeletions when provider transitions NotReady -> Ready", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
+			It("calls ReactivateProviderDeletions when provider transitions Unavailable -> Ready", func() {
+				server := healthyServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -384,7 +484,7 @@ var _ = Describe("Monitor", func() {
 							ID:                  providerID,
 							Name:                "recovered-provider",
 							Endpoint:            server.URL,
-							HealthStatus:        model.HealthStatusNotReady,
+							HealthStatus:        model.HealthStatusUnavailable,
 							ConsecutiveFailures: 5,
 						},
 					},
@@ -399,10 +499,33 @@ var _ = Describe("Monitor", func() {
 				Expect(instStore.markProviderDeletionsCalls).To(BeEmpty())
 			})
 
+			It("calls ReactivateProviderDeletions when provider transitions Unhealthy -> Ready", func() {
+				server := healthyServer()
+				defer server.Close()
+
+				providerID := uuid.New().String()
+				mockStore := &mockProviderStore{
+					providers: model.ProviderList{
+						{
+							ID:           providerID,
+							Name:         "recovered-provider",
+							Endpoint:     server.URL,
+							HealthStatus: model.HealthStatusUnhealthy,
+						},
+					},
+				}
+
+				instStore := &mockInstanceStore{}
+				monitor = healthcheck.NewMonitor(mockStore, instStore, cfg)
+				monitor.CheckProviders(ctx)
+
+				Expect(instStore.reactivateProviderCalls).To(HaveLen(1))
+				Expect(instStore.reactivateProviderCalls[0]).To(Equal("recovered-provider"))
+				Expect(instStore.markProviderDeletionsCalls).To(BeEmpty())
+			})
+
 			It("does not call either method when provider stays Ready", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusOK)
-				}))
+				server := healthyServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -425,10 +548,8 @@ var _ = Describe("Monitor", func() {
 				Expect(instStore.reactivateProviderCalls).To(BeEmpty())
 			})
 
-			It("does not call either method when provider stays NotReady", func() {
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					w.WriteHeader(http.StatusInternalServerError)
-				}))
+			It("does not call either method when provider stays Unavailable", func() {
+				server := failingServer()
 				defer server.Close()
 
 				providerID := uuid.New().String()
@@ -438,8 +559,32 @@ var _ = Describe("Monitor", func() {
 							ID:                  providerID,
 							Name:                "still-down-provider",
 							Endpoint:            server.URL,
-							HealthStatus:        model.HealthStatusNotReady,
+							HealthStatus:        model.HealthStatusUnavailable,
 							ConsecutiveFailures: 5,
+						},
+					},
+				}
+
+				instStore := &mockInstanceStore{}
+				monitor = healthcheck.NewMonitor(mockStore, instStore, cfg)
+				monitor.CheckProviders(ctx)
+
+				Expect(instStore.markProviderDeletionsCalls).To(BeEmpty())
+				Expect(instStore.reactivateProviderCalls).To(BeEmpty())
+			})
+
+			It("does not call either method when provider stays Unhealthy", func() {
+				server := unhealthyServer()
+				defer server.Close()
+
+				providerID := uuid.New().String()
+				mockStore := &mockProviderStore{
+					providers: model.ProviderList{
+						{
+							ID:           providerID,
+							Name:         "still-unhealthy-provider",
+							Endpoint:     server.URL,
+							HealthStatus: model.HealthStatusUnhealthy,
 						},
 					},
 				}

--- a/internal/service/resource_manager/service_type_instance_test.go
+++ b/internal/service/resource_manager/service_type_instance_test.go
@@ -153,7 +153,7 @@ var _ = Describe("InstanceService", func() {
 				Name:         "not-ready-provider",
 				ServiceType:  "vm",
 				Endpoint:     mockProvider.URL,
-				HealthStatus: model.HealthStatusNotReady,
+				HealthStatus: model.HealthStatusUnavailable,
 			}
 			Expect(db.Create(&notReadyProvider).Error).NotTo(HaveOccurred())
 

--- a/internal/store/model/provider.go
+++ b/internal/store/model/provider.go
@@ -11,8 +11,10 @@ type HealthStatus string
 const (
 	// HealthStatusReady indicates the provider is healthy and ready to serve requests
 	HealthStatusReady HealthStatus = "ready"
-	// HealthStatusNotReady indicates the provider is not healthy or unreachable
-	HealthStatusNotReady HealthStatus = "not_ready"
+	// HealthStatusUnhealthy indicates the provider is reachable but the backing provider is unavailable
+	HealthStatusUnhealthy HealthStatus = "unhealthy"
+	// HealthStatusUnavailable indicates the provider is unreachable
+	HealthStatusUnavailable HealthStatus = "unavailable"
 )
 
 func (h HealthStatus) StringPtr() *string {

--- a/internal/store/provider/provider_test.go
+++ b/internal/store/provider/provider_test.go
@@ -369,20 +369,20 @@ var _ = Describe("Provider Store", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			nextCheck := time.Now().Add(1 * time.Hour)
-			err = providerStore.UpdateHealthStatus(ctx, p.ID, model.HealthStatusNotReady, 3, nextCheck)
+			err = providerStore.UpdateHealthStatus(ctx, p.ID, model.HealthStatusUnavailable, 3, nextCheck)
 
 			Expect(err).NotTo(HaveOccurred())
 
 			updated, err := providerStore.Get(ctx, p.ID)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(updated.HealthStatus).To(Equal(model.HealthStatusNotReady))
+			Expect(updated.HealthStatus).To(Equal(model.HealthStatusUnavailable))
 			Expect(updated.ConsecutiveFailures).To(Equal(3))
 			Expect(updated.NextHealthCheck).NotTo(BeNil())
 		})
 
 		It("updates health status to ready", func() {
 			p := newProvider("health-ready")
-			p.HealthStatus = model.HealthStatusNotReady
+			p.HealthStatus = model.HealthStatusUnavailable
 			p.ConsecutiveFailures = 5
 			_, err := providerStore.Create(ctx, p)
 			Expect(err).NotTo(HaveOccurred())

--- a/internal/store/resource_manager/service_instance.go
+++ b/internal/store/resource_manager/service_instance.go
@@ -307,7 +307,7 @@ func (s *ServiceTypeInstanceStore) MarkPendingProviderIfNotReady(ctx context.Con
 		Model(&model.ServiceTypeInstance{}).
 		Where("id = ? AND provider_name IN (?)",
 			instanceID,
-			s.db.Model(&model.Provider{}).Select("name").Where("health_status = ?", model.HealthStatusNotReady),
+			s.db.Model(&model.Provider{}).Select("name").Where("health_status IN ?", []model.HealthStatus{model.HealthStatusUnhealthy, model.HealthStatusUnavailable}),
 		).
 		Update("deletion_status", DeletionStatusPendingProvider)
 	if result.Error != nil {

--- a/internal/store/resource_manager/service_instance_test.go
+++ b/internal/store/resource_manager/service_instance_test.go
@@ -482,9 +482,23 @@ var _ = Describe("ServiceTypeInstance Store", func() {
 			}
 		})
 
-		It("parks instance and returns true when provider is NotReady", func() {
-			addProvider(kubevirtProvider, model.HealthStatusNotReady)
+		It("parks instance and returns true when provider is Unavailable", func() {
+			addProvider(kubevirtProvider, model.HealthStatusUnavailable)
 			inst := addInstanceToStore(newServiceTypeInstance(kubevirtProvider, "to-park", map[string]any{}))
+			Expect(s.MarkForDeletion(ctx, inst.ID)).To(Succeed())
+
+			marked, err := s.MarkPendingProviderIfNotReady(ctx, inst.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(marked).To(BeTrue())
+
+			found, err := s.Get(ctx, inst.ID, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(*found.DeletionStatus).To(Equal("PENDING_PROVIDER"))
+		})
+
+		It("parks instance and returns true when provider is Unhealthy", func() {
+			addProvider(kubevirtProvider, model.HealthStatusUnhealthy)
+			inst := addInstanceToStore(newServiceTypeInstance(kubevirtProvider, "to-park-unhealthy", map[string]any{}))
 			Expect(s.MarkForDeletion(ctx, inst.ID)).To(Succeed())
 
 			marked, err := s.MarkPendingProviderIfNotReady(ctx, inst.ID)
@@ -511,7 +525,7 @@ var _ = Describe("ServiceTypeInstance Store", func() {
 		})
 
 		It("is idempotent when instance is already PENDING_PROVIDER", func() {
-			addProvider(kubevirtProvider, model.HealthStatusNotReady)
+			addProvider(kubevirtProvider, model.HealthStatusUnavailable)
 			inst := addInstanceToStore(newServiceTypeInstance(kubevirtProvider, "already-marked", map[string]any{}))
 			Expect(s.MarkForDeletion(ctx, inst.ID)).To(Succeed())
 

--- a/test/e2e/service_instance_test.go
+++ b/test/e2e/service_instance_test.go
@@ -488,6 +488,72 @@ var _ = Describe("Service Instance API", func() {
 			Expect(getResp.StatusCode()).To(Equal(http.StatusNotFound))
 		})
 
+		It("transitions to PENDING_PROVIDER when provider reports unhealthy and back to SCHEDULED on recovery", func() {
+			createInstance()
+			clearDeleteStubAndStubFailure()
+
+			// Deferred delete → SCHEDULED
+			deferred := true
+			deleteResp, err := rmApiClient.DeleteInstanceWithResponse(ctx, instID, &resource_manager.DeleteInstanceParams{
+				Deferred: &deferred,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteResp.StatusCode()).To(Equal(http.StatusNoContent))
+
+			showDeleted := true
+			getResp, err := rmApiClient.GetInstanceWithResponse(ctx, instID, &resource_manager.GetInstanceParams{
+				ShowDeleted: &showDeleted,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getResp.StatusCode()).To(Equal(http.StatusOK))
+			Expect(*getResp.JSON200.DeletionStatus).To(Equal(resource_manager.SCHEDULED))
+
+			// Stub unhealthy response → provider becomes Unhealthy
+			stubProviderHealthUnhealthy()
+			waitForProviderUnhealthy(apiClient, ctx, providerID)
+
+			// Instance should transition to PENDING_PROVIDER
+			Eventually(func() resource_manager.ServiceTypeInstanceDeletionStatus {
+				resp, err := rmApiClient.GetInstanceWithResponse(ctx, instID, &resource_manager.GetInstanceParams{
+					ShowDeleted: &showDeleted,
+				})
+				if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.DeletionStatus == nil {
+					return ""
+				}
+				return *resp.JSON200.DeletionStatus
+			}, 30*time.Second, 1*time.Second).Should(Equal(resource_manager.PENDINGPROVIDER))
+
+			// Restore healthy stub → provider recovers
+			resetHealthStubs()
+			stubProviderHealthEndpoint()
+			waitForProviderReady(apiClient, ctx, providerID)
+
+			// Instance should transition back to SCHEDULED
+			Eventually(func() resource_manager.ServiceTypeInstanceDeletionStatus {
+				resp, err := rmApiClient.GetInstanceWithResponse(ctx, instID, &resource_manager.GetInstanceParams{
+					ShowDeleted: &showDeleted,
+				})
+				if err != nil || resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.DeletionStatus == nil {
+					return ""
+				}
+				return *resp.JSON200.DeletionStatus
+			}, 30*time.Second, 1*time.Second).Should(Equal(resource_manager.SCHEDULED))
+
+			// Clean up: restore delete stub and hard-delete
+			resetDeleteStubs()
+			stubProviderDeleteInstance()
+
+			deleteResp, err = rmApiClient.DeleteInstanceWithResponse(ctx, instID, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deleteResp.StatusCode()).To(Equal(http.StatusNoContent))
+
+			getResp, err = rmApiClient.GetInstanceWithResponse(ctx, instID, &resource_manager.GetInstanceParams{
+				ShowDeleted: &showDeleted,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(getResp.StatusCode()).To(Equal(http.StatusNotFound))
+		})
+
 		It("can re-delete a soft-deleted instance when SP becomes available", func() {
 			createInstance()
 			clearDeleteStubAndStubFailure()

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -46,7 +46,7 @@ func stubProviderHealthEndpoint() {
 				"Content-Type": "application/json",
 			},
 			"jsonBody": map[string]interface{}{
-				"status": "ok",
+				"status": "healthy",
 			},
 		},
 	}
@@ -68,6 +68,28 @@ func waitForProviderReady(apiClient *providerclient.ClientWithResponses, ctx con
 		}
 		return *getResp.JSON200.HealthStatus
 	}, 30*time.Second, 1*time.Second).Should(Equal("ready"), "Provider should become ready")
+}
+
+func stubProviderHealthUnhealthy() {
+	resetHealthStubs()
+	stub := map[string]interface{}{
+		"request": map[string]interface{}{
+			"method":  "GET",
+			"urlPath": "/health",
+		},
+		"response": map[string]interface{}{
+			"status": 200,
+			"headers": map[string]string{
+				"Content-Type": "application/json",
+			},
+			"jsonBody": map[string]interface{}{
+				"status": "unhealthy",
+			},
+		},
+	}
+
+	body, _ := json.Marshal(stub)
+	http.Post(wireMockURL()+"/__admin/mappings", "application/json", bytes.NewReader(body))
 }
 
 func stubProviderCreateInstance() {
@@ -178,5 +200,18 @@ func waitForProviderNotReady(apiClient *providerclient.ClientWithResponses, ctx 
 			return ""
 		}
 		return *getResp.JSON200.HealthStatus
-	}, 60*time.Second, 1*time.Second).Should(Equal("not_ready"), "Provider should become not ready")
+	}, 60*time.Second, 1*time.Second).Should(Equal("unavailable"), "Provider should become unavailable")
+}
+
+func waitForProviderUnhealthy(apiClient *providerclient.ClientWithResponses, ctx context.Context, providerID string) {
+	Eventually(func() string {
+		getResp, err := apiClient.GetProviderWithResponse(ctx, providerID)
+		if err != nil || getResp.StatusCode() != http.StatusOK || getResp.JSON200 == nil {
+			return ""
+		}
+		if getResp.JSON200.HealthStatus == nil {
+			return ""
+		}
+		return *getResp.JSON200.HealthStatus
+	}, 60*time.Second, 1*time.Second).Should(Equal("unhealthy"), "Provider should become unhealthy")
 }


### PR DESCRIPTION
Backport #65

Replace the binary Ready/NotReady health model with a three-state model (Ready, Unhealthy, Unavailable) to distinguish between an unreachable service provider and one whose backing provider is unavailable.

The previous two-state model could not differentiate between a service provider that is down and one that is up but whose backing provider is unavailable. This distinction is needed so DCM can make better scheduling decisions.

- Replace HealthStatusNotReady with HealthStatusUnhealthy (reachable but backing provider unavailable) and HealthStatusUnavailable (unreachable)
- Parse the health endpoint JSON response body to determine backing provider health via the status field (healthy/unhealthy)
- Transition to Unhealthy immediately on 200 OK with status "unhealthy", without requiring consecutive failures
- Apply exponential backoff only for Unavailable providers; Unhealthy providers use the standard check interval since they are reachable
- Park deletions on transition to either Unhealthy or Unavailable, reactivate on recovery to Ready
- Update store query to match both Unhealthy and Unavailable statuses when marking pending provider deletions

Added unit tests for the Unhealthy state across monitor, store, and cleanup scheduler packages, covering health check transitions, backoff scheduling, deletion parking, and reactivation.