### PR TITLE
Reset health backoff when provider re-registers

### DIFF
--- a/internal/service/provider/provider.go
+++ b/internal/service/provider/provider.go
@@ -55,6 +55,8 @@ func (s *ProviderService) RegisterOrUpdateProvider(ctx context.Context, req *pro
 
 	if existing != nil {
 		log.Debug("Existing provider found, updating", "provider_id", existing.ID, "name", req.Name)
+		existing.ConsecutiveFailures = 0
+		existing.NextHealthCheck = nil
 		updated, err := s.updateExistingProvider(ctx, existing, req)
 		if err != nil {
 			return nil, false, err

--- a/internal/service/provider/provider_test.go
+++ b/internal/service/provider/provider_test.go
@@ -3,6 +3,7 @@ package provider_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	providerserver "github.com/dcm-project/service-provider-manager/internal/api/server/provider"
 	"github.com/dcm-project/service-provider-manager/internal/service"
@@ -160,6 +161,32 @@ var _ = Describe("ProviderService", func() {
 			val3, ok := got.Metadata.Get("supportedPlatforms")
 			Expect(ok).To(BeTrue())
 			Expect(val3).To(Equal("kubevirt"))
+		})
+
+		It("resets health backoff on re-register", func() {
+			req := newProvider("health-reset")
+			resp, _, err := providerService.RegisterOrUpdateProvider(ctx, req, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			futureCheck := time.Now().Add(24 * time.Hour)
+			err = db.Model(&model.Provider{}).Where("id = ?", *resp.Id).Updates(map[string]any{
+				"health_status":        model.HealthStatusUnavailable,
+				"consecutive_failures": 5,
+				"next_health_check":    futureCheck,
+			}).Error
+			Expect(err).NotTo(HaveOccurred())
+
+			req2 := newProvider("health-reset")
+			req2.Id = resp.Id
+			_, updated, err := providerService.RegisterOrUpdateProvider(ctx, req2, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+
+			var p model.Provider
+			Expect(db.Where("id = ?", *resp.Id).First(&p).Error).NotTo(HaveOccurred())
+			Expect(p.ConsecutiveFailures).To(Equal(0))
+			Expect(p.NextHealthCheck).To(BeNil())
+			Expect(p.HealthStatus).To(Equal(model.HealthStatusUnavailable))
 		})
 
 		It("returns conflict when name exists with different ID", func() {
@@ -324,6 +351,35 @@ var _ = Describe("ProviderService", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(updated.Endpoint).To(Equal("https://updated.example.com"))
+		})
+
+		It("preserves health backoff on field update", func() {
+			req := newProvider("health-preserve")
+			resp, _, err := providerService.RegisterOrUpdateProvider(ctx, req, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			futureCheck := time.Now().Add(24 * time.Hour)
+			err = db.Model(&model.Provider{}).Where("id = ?", *resp.Id).Updates(map[string]any{
+				"health_status":        model.HealthStatusUnavailable,
+				"consecutive_failures": 5,
+				"next_health_check":    futureCheck,
+			}).Error
+			Expect(err).NotTo(HaveOccurred())
+
+			update := &providerserver.Provider{
+				Name:          "health-preserve",
+				Endpoint:      "https://updated.example.com",
+				ServiceType:   "vm",
+				SchemaVersion: "v1alpha1",
+			}
+			_, err = providerService.UpdateProvider(ctx, *resp.Id, update)
+			Expect(err).NotTo(HaveOccurred())
+
+			var p model.Provider
+			Expect(db.Where("id = ?", *resp.Id).First(&p).Error).NotTo(HaveOccurred())
+			Expect(p.ConsecutiveFailures).To(Equal(5))
+			Expect(p.NextHealthCheck).NotTo(BeNil())
+			Expect(p.HealthStatus).To(Equal(model.HealthStatusUnavailable))
 		})
 
 		It("returns conflict when renaming to existing name", func() {

--- a/internal/store/provider/provider.go
+++ b/internal/store/provider/provider.go
@@ -123,6 +123,7 @@ func (s *ProviderStore) Update(ctx context.Context, provider model.Provider) (*m
 		Select(
 			"Name", "ServiceType", "SchemaVersion", "Endpoint",
 			"DisplayName", "Operations", "Metadata", "UpdateTime",
+			"ConsecutiveFailures", "NextHealthCheck",
 		).Updates(&provider)
 	if result.Error != nil {
 		return nil, result.Error


### PR DESCRIPTION
## Summary
- Clear `ConsecutiveFailures` and `NextHealthCheck` when a provider re-registers via `RegisterOrUpdateProvider`, so the health monitor picks it up on the next tick instead of leaving it stuck behind a stale backoff window
- Scoped to re-registration only — the `UpdateProvider` (PATCH/PUT) path preserves health state so routine field updates don't silently reset backoff
- `HealthStatus` is intentionally preserved; the health monitor confirms health before promoting back to "ready"

## Test plan
- [x] Unit test: re-register resets `ConsecutiveFailures` to 0 and `NextHealthCheck` to nil
- [x] Unit test: `UpdateProvider` preserves existing health backoff state
- [x] Full suite passes (`go test ./...`)
- [x] Deploy to test cluster with `quay.io/chadcrum0/test:service-provider-manager-FLPATH-4331_sprm-reset-health-on-reregister` and verify provider recovery after restart

Ref: [FLPATH-4331](https://issues.redhat.com/browse/FLPATH-4331)

🤖 Generated with [Claude Code](https://claude.com/claude-code)